### PR TITLE
support multiple module loaders and process types

### DIFF
--- a/positron/components/ModuleLoader.jsm
+++ b/positron/components/ModuleLoader.jsm
@@ -65,7 +65,7 @@ function ModuleLoader(processType) {
    * @param  path     {string} the path to the module being imported.
    * @return          {Object} an `exports` object.
    */
-  let require = this.require = function(requirer, path) {
+  this.require = function(requirer, path) {
     let uri, file;
 
     // dump('require: ' + requirer.id + ' requires ' + path + '\n');
@@ -132,7 +132,7 @@ function ModuleLoader(processType) {
       wantComponents: wantComponents,
     });
 
-    injectGlobals(sandbox, module);
+    this.injectGlobals(sandbox, module);
 
     // XXX Move these into injectGlobals().
     sandbox.__filename = file.path;
@@ -149,13 +149,13 @@ function ModuleLoader(processType) {
     }
   };
 
-  let injectGlobals = this.injectGlobals = function(globalObj, module) {
+  this.injectGlobals = function(globalObj, module) {
     globalObj.exports = module.exports;
     globalObj.module = module;
-    globalObj.require = require.bind(null, module);
+    globalObj.require = this.require.bind(this, module);
     // Require `process` by absolute URL so the resolution algorithm doesn't try
     // to resolve it relative to the requirer's URL.
-    globalObj.process = require({}, 'resource:///modules/node/process.js');
+    globalObj.process = this.require({}, 'resource:///modules/node/process.js');
     globalObj.process.type = processType;
   };
 }

--- a/positron/components/ModuleLoader.jsm
+++ b/positron/components/ModuleLoader.jsm
@@ -56,7 +56,7 @@ function ModuleLoader(processType) {
    * @keys {string} The ID (resource: URL) for the module.
    * @values {object} An object representing the module.
    */
-  let modules = new Map();
+  const modules = new Map();
 
   /**
    * Import a module.

--- a/positron/components/ModuleLoader.jsm
+++ b/positron/components/ModuleLoader.jsm
@@ -23,16 +23,13 @@ this.EXPORTED_SYMBOLS = ["ModuleLoader"];
 const systemPrincipal = Cc["@mozilla.org/systemprincipal;1"].
                         createInstance(Ci.nsIPrincipal);
 
-// An (incomplete) list of "global paths" (i.e. search paths for modules
-// specified by name rather than path).  Currently this is a single list,
-// but it needs to vary by process type, as the browser and renderer processes
-// have their own sets of standard modules (in addition to the shared set).
-const globalPaths = [
-  // Browser standard modules.
-  'browser/api/exports/',
-
-  // Common standard modules.
-  'common/api/',
+// The default list of "global paths" (i.e. search paths for modules
+// specified by name rather than path).  The list of global paths for a given
+// ModuleLoader depends on the process type, so the ModuleLoader constructor
+// clones this list and prepends a process-type-specific path to the clone.
+const DEFAULT_GLOBAL_PATHS = [
+  // Electron standard modules that are common to both process types.
+  'common/api/exports/',
 
   // Modules that are imported via process.atomBinding().  In Electron,
   // these are all natives; in Positron, they're currently all JavaScript.
@@ -50,6 +47,10 @@ const globalPaths = [
  */
 
 function ModuleLoader(processType) {
+  const globalPaths = DEFAULT_GLOBAL_PATHS.slice();
+  // Prepend a process-type-specific path to the global paths for this loader.
+  globalPaths.unshift(processType + '/api/exports/');
+
   /**
    * Mapping from module IDs (resource: URLs) to module objects.
    *

--- a/positron/components/PositronAppRunner.jsm
+++ b/positron/components/PositronAppRunner.jsm
@@ -13,7 +13,7 @@ const NS_OK = Cr.NS_OK;
 
 Cu.import("resource://gre/modules/NetUtil.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource:///modules/Require.jsm");
+Cu.import("resource:///modules/ModuleLoader.jsm");
 
 this.EXPORTED_SYMBOLS = ["PositronAppRunner"];
 
@@ -60,7 +60,8 @@ PositronAppRunner.prototype = {
       id: "resource:///modules/PositronAppRunner.jsm",
       exports: {},
     };
-    (new Require(requirer))(Services.io.newFileURI(mainScript).spec);
+    let loader = new ModuleLoader("browser" /* processType */);
+    loader.require(requirer, Services.io.newFileURI(mainScript).spec);
   },
 
   _parsePackageJSON: function par_parsePackageJSON(aData) {

--- a/positron/components/moz.build
+++ b/positron/components/moz.build
@@ -8,6 +8,6 @@ EXTRA_COMPONENTS += [
 ]
 
 EXTRA_JS_MODULES += [
+    'ModuleLoader.jsm',
     'PositronAppRunner.jsm',
-    'Require.jsm',
 ]

--- a/positron/node/lib/process.js
+++ b/positron/node/lib/process.js
@@ -5,6 +5,11 @@
 // expects, then construct the `process` global from it (instead of the other
 // way around).  We can presumably stop doing that once we're using real Node.
 
+// Because we construct the `process` global in this module, and we also inject
+// the global into this module, we don't actually have to export its symbols
+// here.  We just have to attach them to this module's own `process` global.
+// XXX Figure out if that's really the best way to implement this functionality.
+
 // Re-export process as a native module
 // module.exports = process;
 
@@ -29,7 +34,3 @@ process.atomBinding = function(name) {
 process.binding = function(name) {
   return require(name);
 }
-
-// This is an Electron extension to the Node process module.
-// XXX Make this return 'renderer' in a renderer "process."
-process.type = 'browser';


### PR DESCRIPTION
This branch makes the module loading module support multiple independent module loaders in preparation for injecting module loading into a renderer "process." (Say that ten times fast.)

