### PR TITLE
warn that WebContents.openDevTools() isn't implemented instead of throwing

### DIFF
--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -29,6 +29,10 @@ let WebContents_prototype = {
   loadURL: function(url) {
     this._browserWindow._domWindow.location = url;
   },
+
+  openDevTools: function() {
+    dump('WebContents.openDevTools is not yet implemented!\n');
+  },
 };
 
 function WebContents(options) {
@@ -40,6 +44,7 @@ function WebContents(options) {
   // it's an alias for getURL).
   this.getURL = this._getURL = WebContents_prototype.getURL;
   this.loadURL = WebContents_prototype.loadURL;
+  this.openDevTools = WebContents_prototype.openDevTools;
 }
 
 exports.create = function(options) {


### PR DESCRIPTION
This warns instead of throwing an exception on `WebContents.openDevTools()`, so the "hello world" app continues after calling that method, and we can test a fix for #5.