### PR TITLE
implement the BrowserWindow.close and app.window-all-closed events (fixes #4, #5)

### DIFF
--- a/positron/modules/atom_browser_window.js
+++ b/positron/modules/atom_browser_window.js
@@ -40,7 +40,7 @@ const DEFAULT_WINDOW_FEATURES = [
   'scrollbars',
 ];
 
-// Map from nsIDOMWindow instances to BrowserWindow instances.
+// Map of DOM window instances to BrowserWindow instances.
 let browserWindows = new Map();
 
 function BrowserWindow(options) {

--- a/positron/modules/atom_browser_window.js
+++ b/positron/modules/atom_browser_window.js
@@ -67,10 +67,9 @@ windowWatcher.registerNotification(function observe(subject, topic, data) {
     case 'domwindowopened':
       break;
     case 'domwindowclosed': {
-      let domWindow = subject.QueryInterface(Ci.nsIDOMWindow);
-      let browserWindow = browserWindows.get(domWindow);
+      let browserWindow = browserWindows.get(subject);
       browserWindow.emit('closed');
-      browserWindows.delete(domWindow);
+      browserWindows.delete(subject);
 
       // This assumes that the BrowserWindow module was loaded before any
       // windows were opened.  That's a safe assumption while the module


### PR DESCRIPTION
This branch implements the *BrowserWindow.close* and *app.window-all-closed* events, fixing #4 and #5.