### PR TITLE
First pass at DevTools for BrowserWindow

### DIFF
--- a/devtools/client/framework/target-from-url.js
+++ b/devtools/client/framework/target-from-url.js
@@ -4,8 +4,6 @@
 
 "use strict";
 
-const { Cu, Ci } = require("chrome");
-
 const { TargetFactory } = require("devtools/client/framework/target");
 const { DebuggerServer } = require("devtools/server/main");
 const { DebuggerClient } = require("devtools/shared/client/main");
@@ -14,27 +12,32 @@ const { Task } = require("resource://gre/modules/Task.jsm");
 /**
  * Construct a Target for a given URL object having various query parameters:
  *
- * type: tab, process
- *    {String} The type of target to connect to.  Currently tabs and processes are supported types.
+ * type: tab, process, window
+ *    {String} The type of target to connect to.
  *
- * If type="tab":
+ * If type == "tab":
  * id:
  *    {Number} the tab outerWindowID
  * chrome: Optional
- *    {Boolean} Force the creation of a chrome target. Gives more privileges to the tab
- *    actor. Allows chrome execution in the webconsole and see chrome files in
- *    the debugger. (handy when contributing to firefox)
+ *    {Boolean} Force the creation of a chrome target. Gives more privileges to
+ *    the tab actor. Allows chrome execution in the webconsole and see chrome
+ *    files in the debugger. (handy when contributing to firefox)
  *
- * If type="process":
+ * If type == "process":
  * id:
- *    {Number} the process id to debug. Default to 0, which is the parent process.
+ *    {Number} the process id to debug. Default to 0, which is the parent
+ *    process.
+ *
+ * If type == "window":
+ * id:
+ *    {Number} the window outerWindowID
  *
  * @param {URL} url
  *        The url to fetch query params from.
  *
  * @return A target object
  */
-exports.targetFromURL = Task.async(function*(url) {
+exports.targetFromURL = Task.async(function* (url) {
   let params = url.searchParams;
   let type = params.get("type");
   if (!type) {
@@ -85,6 +88,26 @@ exports.targetFromURL = Task.async(function*(url) {
     } catch(ex) {
       if (ex.error == "noProcess") {
         throw new Error("targetFromURL, process with id:'" + id+ "' doesn't exist");
+      }
+      throw ex;
+    }
+  } else if (type == "window") {
+    // Fetch target for a remote window actor
+    DebuggerServer.allowChromeProcess = true;
+    try {
+      id = parseInt(id, 10);
+      if (isNaN(id)) {
+        throw new Error("targetFromURL, window requires id parameter");
+      }
+      let response = yield client.mainRoot.getWindow({
+        outerWindowID: id,
+      });
+      form = response.window;
+      chrome = true;
+    } catch (ex) {
+      if (ex.error == "notFound") {
+        throw new Error(`targetFromURL, window with id:'${id}' ` +
+                        "doesn't exist");
       }
       throw ex;
     }

--- a/devtools/client/framework/test/browser_target_from_url.js
+++ b/devtools/client/framework/test/browser_target_from_url.js
@@ -27,8 +27,19 @@ add_task(function*() {
     is(e.message, "targetFromURL, unsupported type='x' parameter");
   }
 
+  info("Test browser window");
+  let windowId = window.QueryInterface(Ci.nsIInterfaceRequestor)
+                       .getInterface(Ci.nsIDOMWindowUtils)
+                       .outerWindowID;
+  target = yield targetFromURL(new URL("http://foo?type=window&id=" + windowId));
+  is(target.url, window.location.href);
+  is(target.isLocalTab, false);
+  is(target.chrome, true);
+  is(target.isTabActor, true);
+  is(target.isRemote, true);
+
   info("Test tab");
-  let windowId = browser.outerWindowID;
+  windowId = browser.outerWindowID;
   target = yield targetFromURL(new URL("http://foo?type=tab&id=" + windowId));
   assertIsTabTarget(target);
 

--- a/devtools/client/framework/toolbox-init.js
+++ b/devtools/client/framework/toolbox-init.js
@@ -26,6 +26,19 @@ if (url.search.length > 1) {
                    .getInterface(Ci.nsIDOMWindowUtils)
                    .containerElement;
 
+  // If there's no containerElement, use the current window.
+  if (!host) {
+    host = {
+      contentWindow: window,
+      contentDocument: document,
+      // toolbox.js wants to set attributes on the frame that contains it, but
+      // that is fine to skip and doesn't make sense when using the current
+      // window.
+      setAttribute() {},
+      ownerDocument: document,
+    };
+  }
+
   // Specify the default tool to open
   let tool = url.searchParams.get("tool");
 

--- a/devtools/server/actors/moz.build
+++ b/devtools/server/actors/moz.build
@@ -62,5 +62,6 @@ DevToolsModules(
     'webbrowser.js',
     'webconsole.js',
     'webgl.js',
+    'window.js',
     'worker.js',
 )

--- a/devtools/server/actors/window.js
+++ b/devtools/server/actors/window.js
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const { Ci } = require("chrome");
+const { TabActor } = require("./webbrowser");
+
+/**
+ * Creates a WindowActor for debugging a single window, like a browser window in
+ * Firefox, but it can be used to reach any window in the process.  Most of the
+ * implementation is inherited from TabActor. WindowActor exposes all tab actors
+ * via its form() request, like TabActor.
+ *
+ * You can request a specific window's actor via RootActor.getWindow().
+ *
+ * @param connection DebuggerServerConnection
+ *        The connection to the client.
+ * @param window DOMWindow
+ *        The window.
+ */
+function WindowActor(connection, window) {
+  TabActor.call(this, connection);
+
+  let docShell = window.QueryInterface(Ci.nsIInterfaceRequestor)
+                       .getInterface(Ci.nsIDocShell);
+  Object.defineProperty(this, "docShell", {
+    value: docShell,
+    configurable: true
+  });
+}
+
+WindowActor.prototype = Object.create(TabActor.prototype);
+
+// Bug 1266561: This setting is mysteriously named, we should split up the
+// functionality that is triggered by it.
+WindowActor.prototype.isRootActor = true;
+
+WindowActor.prototype.observe = function(subject, topic, data) {
+  TabActor.prototype.observe.call(this, subject, topic, data);
+  if (!this.attached) {
+    return;
+  }
+  if (topic == "chrome-webnavigation-create") {
+    subject.QueryInterface(Ci.nsIDocShell);
+    this._onDocShellCreated(subject);
+  } else if (topic == "chrome-webnavigation-destroy") {
+    this._onDocShellDestroy(subject);
+  }
+};
+
+WindowActor.prototype._attach = function() {
+  if (this.attached) {
+    return false;
+  }
+
+  TabActor.prototype._attach.call(this);
+
+  // Listen for chrome docshells in addition to content docshells
+  if (this.listenForNewDocShells) {
+    Services.obs.addObserver(this, "chrome-webnavigation-create", false);
+  }
+  Services.obs.addObserver(this, "chrome-webnavigation-destroy", false);
+
+  return true;
+};
+
+WindowActor.prototype._detach = function() {
+  if (!this.attached) {
+    return false;
+  }
+
+  if (this.listenForNewDocShells) {
+    Services.obs.removeObserver(this, "chrome-webnavigation-create");
+  }
+  Services.obs.removeObserver(this, "chrome-webnavigation-destroy");
+
+  TabActor.prototype._detach.call(this);
+
+  return true;
+};
+
+exports.WindowActor = WindowActor;

--- a/devtools/server/docs/actor-hierarchy.md
+++ b/devtools/server/docs/actor-hierarchy.md
@@ -7,7 +7,8 @@ once a parent is removed from the pool, its children are removed as well.
 
 The overall hierarchy of actors looks like this:
 
-  RootActor: First one, automatically instantiated when we start connecting.
+```
+RootActor: First one, automatically instantiated when we start connecting.
    |         Mostly meant to instantiate new actors.
    |
    |--> Global-scoped actors:
@@ -27,6 +28,7 @@ The overall hierarchy of actors looks like this:
                worker).  Examples include the console and inspector actors.
                These actors may extend this hierarchy by having their
                own children, like LongStringActor, WalkerActor, etc.
+```
 
 ## RootActor
 
@@ -36,7 +38,8 @@ All other actors have an `actorID` which is computed dynamically,
 so that you need to ask an existing actor to create an Actor
 and returns its `actorID`. That's the main role of RootActor.
 
-  RootActor (root.js)
+```
+RootActor (root.js)
    |
    |-- BrowserTabActor (webbrowser.js)
    |   Targets tabs living in the parent process when e10s (multiprocess)
@@ -81,6 +84,7 @@ and returns its `actorID`. That's the main role of RootActor.
    \-- BrowserAddonActor (addon.js)
        Targets the javascript of add-ons.
        Returned by "listAddons" request.
+```
 
 ## "TabActor"
 

--- a/devtools/server/docs/actor-hierarchy.md
+++ b/devtools/server/docs/actor-hierarchy.md
@@ -63,6 +63,11 @@ and returns its `actorID`. That's the main role of RootActor.
    |   Returned by "listWorkers" request to a ChildProcessActor to get workers
    |   for the chrome of the child process.
    |
+   |-- WindowActor (window.js)
+   |   Targets a single window, such as a browser window in Firefox, but it can
+   |   be used to reach any window in the parent process.
+   |   Returned by "getWindow" request to the root actor.
+   |
    |-- ChromeActor (chrome.js)
    |   Targets all resources in the parent process of firefox
    |   (chrome documents, JSM, JS XPCOM, etc.).

--- a/devtools/shared/client/main.js
+++ b/devtools/shared/client/main.js
@@ -1654,6 +1654,27 @@ RootClient.prototype = {
   },
 
   /**
+   * Fetch the WindowActor for a specific window, like a browser window in
+   * Firefox, but it can be used to reach any window in the process.
+   *
+   * @param number outerWindowID
+   *        The outerWindowID of the top level window you are looking for.
+   */
+  getWindow: function({ outerWindowID }) {
+    if (!outerWindowID) {
+      throw new Error("Must specify outerWindowID");
+    }
+
+    let packet = {
+      to: this.actor,
+      type: "getWindow",
+      outerWindowID,
+    };
+
+    return this.request(packet);
+  },
+
+  /**
    * Description of protocol's actors and methods.
    *
    * @param function aOnResponse

--- a/positron/app/positron.js
+++ b/positron/app/positron.js
@@ -4,3 +4,4 @@
 
 pref("browser.dom.window.dump.enabled", true);
 pref("javascript.options.showInConsole", true);
+pref("devtools.selfxss.count", 5);

--- a/positron/confvars.sh
+++ b/positron/confvars.sh
@@ -9,3 +9,6 @@ MOZ_CHROME_FILE_FORMAT=omni
 
 #XXXkhuey I have no idea why startupcache doesn't work
 MOZ_DISABLE_STARTUPCACHE=1
+
+# Include the DevTools client, not just the server (which is the default).
+MOZ_DEVTOOLS=all

--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -4,6 +4,9 @@
 
 "use strict";
 
+const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
+const { Services } = Cu.import("resource://gre/modules/Services.jsm", {});
+
 let wrapWebContents = null;
 
 exports._setWrapWebContents = function(aWrapWebContents) {
@@ -30,8 +33,54 @@ let WebContents_prototype = {
     this._browserWindow._domWindow.location = url;
   },
 
-  openDevTools: function() {
-    dump('WebContents.openDevTools is not yet implemented!\n');
+  openDevTools() {
+    // TODO: When tools can be opened inside the content window, support
+    // `detach` option to force into a new window instead.
+
+    // Ensure DevTools core modules are loaded, including support for the about
+    // URL below which is registered dynamically.
+    const { loader } = Cu.import("resource://devtools/shared/Loader.jsm", {});
+    loader.require("devtools/client/main");
+
+    // The current approach below avoids the need for a container window
+    // wrapping a tools frame, but it does replicate close handling, etc.
+    // Historically we would have used toolbox-hosts.js to handle this, but
+    // DevTools will be moving away from that, and so it seems fine to
+    // experiment with toolbox management here.
+    let window = this._browserWindow._domWindow;
+    let id = window.QueryInterface(Ci.nsIInterfaceRequestor)
+                   .getInterface(Ci.nsIDOMWindowUtils)
+                   .outerWindowID;
+    let url = `about:devtools-toolbox?type=window&id=${id}`;
+    let features = "chrome,resizable,centerscreen," +
+                   "width=1024,height=768";
+    let toolsWindow = Services.ww.openWindow(null, url, null, features, null);
+
+    // Emit DevTools events that are in the webContents API
+    let onLoad = () => {
+      toolsWindow.removeEventListener("load", onLoad);
+      toolsWindow.addEventListener("unload", onUnload);
+      this.emit("devtools-opened");
+    }
+    let onUnload = () => {
+      toolsWindow.removeEventListener("unload", onUnload);
+      toolsWindow.removeEventListener("message", onMessage);
+      this.emit("devtools-closed");
+    }
+
+    // Listen for the toolbox's built-in close button, which sends a message
+    // asking the toolbox's opener how to handle things.  In this case, just
+    // close the toolbox.
+    let onMessage = ({ data }) => {
+      data = JSON.parse(data);
+      if (data.name !== "toolbox-close") {
+        return;
+      }
+      toolsWindow.close();
+    };
+
+    toolsWindow.addEventListener("message", onMessage);
+    toolsWindow.addEventListener("load", onLoad);
   },
 };
 


### PR DESCRIPTION
I've added support to open the DevTools when calling `BrowserWindow.webContents.openDevTools()` as in the example app (so this fixes #3).

I added some additional abilities to the tools for targeting specific windows directly to help with this case. I've kept all the `/devtools` changes in separate commits from `/positron` ones, for hopefully easier merging if bits are landed in m-c later.

~~The tools seems to be up and running in general, but there's a few rough edges for now, like you get a giant error on quit if the tools are still open. I figured I would resolve these things separately.~~ (Error on quit now resolved.)

@mykmelez, maybe you can review?