### PR TITLE
fix exposure of process global to window contexts

### DIFF
--- a/positron/components/ModuleLoader.jsm
+++ b/positron/components/ModuleLoader.jsm
@@ -66,7 +66,7 @@ function ModuleLoader(processType) {
    * to the `global` symbol as well as implicitly via the sandbox prototype.
    * This object is shared across all modules loaded by this loader.
    */
-  const global = {
+  this.global = {
     // Start defining the `process` property.  We finish defining it below,
     // after defining this.require().
     process: {
@@ -87,7 +87,7 @@ function ModuleLoader(processType) {
     moduleGlobalObj.exports = module.exports;
     moduleGlobalObj.module = module;
     moduleGlobalObj.require = this.require.bind(this, module);
-    moduleGlobalObj.global = global;
+    moduleGlobalObj.global = this.global;
   };
 
   /**
@@ -162,7 +162,7 @@ function ModuleLoader(processType) {
     let sandbox = new Cu.Sandbox(systemPrincipal, {
       sandboxName: uri.spec,
       wantComponents: wantComponents,
-      sandboxPrototype: global,
+      sandboxPrototype: this.global,
     });
 
     this.injectModuleGlobals(sandbox, module);

--- a/positron/components/Process.js
+++ b/positron/components/Process.js
@@ -20,7 +20,7 @@ Cu.import('resource:///modules/ModuleLoader.jsm');
 function Process() {}
 
 Process.prototype = {
-  _processModule: null,
+  _processGlobal: null,
 
   classID: Components.ID('{3c81d709-5fb4-4144-9612-9ecc1be4e7b1}'),
   contractID: '@mozilla.org/positron/process;1',
@@ -38,14 +38,14 @@ Process.prototype = {
    */
   init: function(window) {
     let loader = ModuleLoader.getLoaderForWindow(window);
-    this._processModule = loader.require({}, 'resource:///modules/gecko/process.js');
+    this._processGlobal = loader.global.process;
     return window.processImpl._create(window, this);
   },
 
   /* Node `process` interface */
 
   get versions() {
-    return this._processModule.versions;
+    return this._processGlobal.versions;
   },
 
 };


### PR DESCRIPTION
Recent changes broke exposure of the *process* global to BrowserWindow contexts. This fixes the problem.
