### PR TITLE
ensure browserWindow on domwindowclosed

### DIFF
--- a/positron/modules/atom_browser_window.js
+++ b/positron/modules/atom_browser_window.js
@@ -68,6 +68,15 @@ windowWatcher.registerNotification(function observe(subject, topic, data) {
       break;
     case 'domwindowclosed': {
       let browserWindow = browserWindows.get(subject);
+      if (!browserWindow) {
+        // The window might be a devtools windows, in which case it won't be
+        // in our list of browser windows.
+        // TODO: figure out if window-all-closed respects devtools windows,
+        // in which case the conditional that determines whether or not to emit
+        // that event will need to change.
+        return;
+      }
+
       browserWindow.emit('closed');
       browserWindows.delete(subject);
 

--- a/positron/modules/atom_browser_window.js
+++ b/positron/modules/atom_browser_window.js
@@ -69,7 +69,7 @@ windowWatcher.registerNotification(function observe(subject, topic, data) {
     case 'domwindowclosed': {
       let browserWindow = browserWindows.get(subject);
       if (!browserWindow) {
-        // The window might be a devtools windows, in which case it won't be
+        // The window might be a devtools window, in which case it won't be
         // in our list of browser windows.
         // TODO: figure out if window-all-closed respects devtools windows,
         // in which case the conditional that determines whether or not to emit


### PR DESCRIPTION
After merging @jryans's devtools branch, I noticed this error when quitting the "hello world" app: `JavaScript error: … resource:///modules/gecko/atom_browser_window.js, line 71: TypeError: browserWindow is undefined`. Presumably it's because the observer gets a notification about the devtools window closing, but that window isn't a BrowserWindow, so it isn't found in `browserWindows`. Thus this branch ensures *browserWindow* before trying to use it.