### PR TITLE
Close DevTools window on browser close

### DIFF
--- a/positron/modules/atom_browser_app.js
+++ b/positron/modules/atom_browser_app.js
@@ -11,7 +11,13 @@ Cu.import('resource://gre/modules/Services.jsm');
 exports.app = {
   quit() {
     // XXX Emit the before-quit and will-quit events.
-    Services.startup.quit(Services.startup.eAttemptQuit);
+    // Wait one turn of the event loop for ancillary windows like DevTools to
+    // close first.
+    Services.tm.mainThread.dispatch({
+      run() {
+        Services.startup.quit(Services.startup.eAttemptQuit);
+      }
+    }, Ci.nsIThread.DISPATCH_NORMAL);
   },
 };
 

--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -68,6 +68,11 @@ let WebContents_prototype = {
       this.emit("devtools-closed");
     }
 
+    // Close the DevTools window if the browser window closes
+    let onBrowserClosed = () => {
+      toolsWindow.close();
+    };
+
     // Listen for the toolbox's built-in close button, which sends a message
     // asking the toolbox's opener how to handle things.  In this case, just
     // close the toolbox.
@@ -81,6 +86,7 @@ let WebContents_prototype = {
 
     toolsWindow.addEventListener("message", onMessage);
     toolsWindow.addEventListener("load", onLoad);
+    this._browserWindow.on("closed", onBrowserClosed);
   },
 };
 


### PR DESCRIPTION
This fixes #29 so that calls to `quit()` after the browser window closes correctly ends the application on Linux (and hopefully Windows as well).

There is still a bit of mystery, as I don't entirely follow why the `unload` handler is needed to make this work. Happy to revise if anyone has ideas!

r? @mykmelez