### PR TITLE
pause until debugger thread resumed so we can debug startup

### DIFF
--- a/devtools/server/actors/script.js
+++ b/devtools/server/actors/script.js
@@ -1031,7 +1031,7 @@ const ThreadActor = ActorClass({
       let packet = this._resumed();
       this._popThreadPause();
       // Tell anyone who cares of the resume (as of now, that's the xpcshell
-      // harness)
+      // harness and devtools-startup.js when handling the --jsdebugger flag)
       if (Services.obs) {
         Services.obs.notifyObservers(this, "devtools-thread-resumed", null);
       }

--- a/devtools/server/actors/webbrowser.js
+++ b/devtools/server/actors/webbrowser.js
@@ -1316,7 +1316,12 @@ TabActor.prototype = {
       // In child processes, we have new root docshells,
       // let's watch them and all their child docshells.
       if (this._isRootDocShell(docShell)) {
-        this._progressListener.watch(docShell);
+        // Don't assume there's a progress listener, since Positron starts
+        // without a window, so this._progressListener never gets created.
+        // TODO: ensure there's a listener for apps without an initial window.
+        if (this._progressListener) {
+          this._progressListener.watch(docShell);
+        }
       }
       this._notifyDocShellsUpdate([docShell]);
     });

--- a/devtools/server/actors/webbrowser.js
+++ b/devtools/server/actors/webbrowser.js
@@ -1399,7 +1399,9 @@ TabActor.prototype = {
     // Stop watching this docshell (the unwatch() method will check if we
     // started watching it before).
     webProgress.QueryInterface(Ci.nsIDocShell);
-    this._progressListener.unwatch(webProgress);
+    if (this._progressListener) {
+      this._progressListener.unwatch(webProgress);
+    }
 
     if (webProgress.DOMWindow == this._originalWindow) {
       // If the original top level document we connected to is removed,
@@ -1480,7 +1482,9 @@ TabActor.prototype = {
     // Check for docShell availability, as it can be already gone
     // during Firefox shutdown.
     if (this.docShell) {
-      this._progressListener.unwatch(this.docShell);
+      if (this._progressListener) {
+        this._progressListener.unwatch(this.docShell);
+      }
       this._restoreDocumentSettings();
     }
     if (this._progressListener) {


### PR DESCRIPTION
@jryans This works as expected when applied on top of #40. Is it something that DevTools might be willing take upstream? Perhaps in coordination with another flag like `--pause-jsdebugger-until-server-thread-resumes-even-if-that-means-hanging-the-app`?

Note: I do see two instances of this error after the server connects:

>Handler function threw an exception: TypeError: this._progressListener is undefined
>Stack: _onDocShellCreated/<@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/server/actors/webbrowser.js:1319:9
>exports.makeInfallible/<@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/shared/ThreadSafeDevToolsUtils.js:101:14
>Line: 1319, column: 9
