### PR TITLE
Include DevTools command line handler via category entry

### DIFF
--- a/devtools/client/devtools-startup.manifest
+++ b/devtools/client/devtools-startup.manifest
@@ -1,2 +1,3 @@
 component {9e9a9283-0ce9-4e4a-8f1c-ba129a032c32} devtools-startup.js
-contract @mozilla.org/toolkit/console-clh;1 {9e9a9283-0ce9-4e4a-8f1c-ba129a032c32}
+contract @mozilla.org/devtools/startup-clh;1 {9e9a9283-0ce9-4e4a-8f1c-ba129a032c32}
+category command-line-handler m-devtools @mozilla.org/devtools/startup-clh;1

--- a/toolkit/components/console/jsconsole-clhandler.manifest
+++ b/toolkit/components/console/jsconsole-clhandler.manifest
@@ -1,3 +1,3 @@
 component {2cd0c310-e127-44d0-88fc-4435c9ab4d4b} jsconsole-clhandler.js
 contract @mozilla.org/toolkit/console-clh;1 {2cd0c310-e127-44d0-88fc-4435c9ab4d4b}
-category command-line-handler b-jsconsole @mozilla.org/toolkit/console-clh;1
+category command-line-handler t-jsconsole @mozilla.org/toolkit/console-clh;1


### PR DESCRIPTION
@mykmelez, here's the `command-line-handler` ordering that should be upstreamable.

It seems to work for Positron and Firefox in my testing.