### PR TITLE
ensure progress listener again

### DIFF
--- a/devtools/server/actors/chrome.js
+++ b/devtools/server/actors/chrome.js
@@ -123,7 +123,9 @@ ChromeActor.prototype._attach = function() {
     if (docShell == this.docShell) {
       continue;
     }
-    this._progressListener.watch(docShell);
+    if (this._progressListener) {
+      this._progressListener.watch(docShell);
+    }
   }
 };
 
@@ -146,7 +148,9 @@ ChromeActor.prototype._detach = function() {
     if (docShell == this.docShell) {
       continue;
     }
-    this._progressListener.unwatch(docShell);
+    if (this._progressListener) {
+      this._progressListener.unwatch(docShell);
+    }
   }
 
   TabActor.prototype._detach.call(this);


### PR DESCRIPTION
@jryans: Here are a couple more places where this._progressListener is assumed, one of which I just hit:

>"Handler function DebuggerTransport.prototype.onInputStreamReady threw an exception: TypeError: this._progressListener is undefined
>Stack: ChromeActor.prototype._detach@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/server/actors/chrome.js:149:5
>exit@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/server/actors/webbrowser.js:1125:9
>disconnect@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/server/actors/webbrowser.js:1108:5
>AP_remove@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/server/actors/common.js:263:7
>AP_destroy@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/server/actors/common.js:225:7
>DSC_onClosed/<@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/server/main.js:1743:40
>DSC_onClosed@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/server/main.js:1743:5
>DebuggerTransport.prototype.close@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/shared/transport/transport.js:212:7
>DebuggerTransport.prototype.onInputStreamReady<@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/shared/transport/transport.js:360:9
>exports.makeInfallible/<@resource://gre/modules/commonjs/toolkit/loader.js -> resource://devtools/shared/ThreadSafeDevToolsUtils.js:101:14
>Line: 149, column: 5"
