### PR TITLE
define IDWeakMap methods on its prototype

### DIFF
--- a/positron/modules/atom_common_id_weak_map.js
+++ b/positron/modules/atom_common_id_weak_map.js
@@ -9,16 +9,25 @@ const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 // Described In Electron's id_weak_map.h as:
 // "Like ES6's WeakMap, but the key is Integer and the value is Weak Pointer."
 
+const instances = new WeakMap();
+
 function IDWeakMap() {
-  const map = new Map();
-  this.set = function(key, value) {
-    map.set(key, Cu.getWeakReference(value));
-  };
-  this.get = function(key) {
-    return map.get(key).get();
-  }
-  this.has = map.has.bind(map);
-  this.clear = map.clear.bind(map);
+  instances.set(this, new Map());
 }
+
+IDWeakMap.prototype = {
+  set(key, value) {
+    instances.get(this).set(key, Cu.getWeakReference(value));
+  },
+  get(key) {
+    return instances.get(this).get(key).get();
+  },
+  has(value) {
+    return instances.get(this).has(value);
+  },
+  clear() {
+    instances.get(this).clear();
+  },
+};
 
 exports.IDWeakMap = IDWeakMap;


### PR DESCRIPTION
@marcoscaceres The only difference from your suggested implementation is that *set* doesn't return `this`, because the upstream implementation doesn't do that:

https://github.com/electron/electron/blob/v0.37.8/atom/common/api/atom_api_id_weak_map.cc#L21-L25
