### PR TITLE
ensure iframe first; set toolboxOpened unconditionally; end after catch

### DIFF
--- a/devtools/client/framework/toolbox-init.js
+++ b/devtools/client/framework/toolbox-init.js
@@ -50,12 +50,12 @@ if (url.search.length > 1) {
     // `iframe` is the targeted document to debug
     let iframe = host.wrappedJSObject ? host.wrappedJSObject.target
                                       : host.target;
-    // Need to use a xray and query some interfaces to have
-    // attributes and behavior expected by devtools codebase
-    iframe = XPCNativeWrapper(iframe);
-    iframe.QueryInterface(Ci.nsIFrameLoaderOwner);
-
     if (iframe) {
+      // Need to use a xray and query some interfaces to have
+      // attributes and behavior expected by devtools codebase
+      iframe = XPCNativeWrapper(iframe);
+      iframe.QueryInterface(Ci.nsIFrameLoaderOwner);
+
       // Fake a xul:tab object as we don't have one.
       // linkedBrowser is the only one attribute being queried by client.getTab
       let tab = { linkedBrowser: iframe };
@@ -79,6 +79,8 @@ if (url.search.length > 1) {
         return gDevTools.showToolbox(target, tool, Toolbox.HostType.CUSTOM,
                                      options);
       });
+    } else {
+      toolboxOpened = Promise.reject(new Error("toolbox target is undefined"));
     }
   } else {
     toolboxOpened = Task.spawn(function*() {
@@ -89,10 +91,6 @@ if (url.search.length > 1) {
     });
   }
 
-  toolboxOpened.catch(e => {
-    window.alert("Unable to start the toolbox: " + e.message);
-  });
-
   // Ensure the toolbox gets destroyed if the host unloads
   toolboxOpened.then(toolbox => {
     let hostUnload = () => {
@@ -100,5 +98,9 @@ if (url.search.length > 1) {
       toolbox.destroy();
     };
     host.contentWindow.addEventListener("unload", hostUnload);
+  });
+
+  toolboxOpened.catch(e => {
+    window.alert("Unable to start the toolbox: " + e.message);
   });
 }


### PR DESCRIPTION
@jryans While resolving conflicts with a merge from upstream, I noticed a few issues with toolbox-init:

1. The script tests `if (iframe)` after calling `iframe.QueryInterface()`, but that call should throw an exception if *iframe* is falsy, so the conditional will never be false.
2. After fixing issue #1 by testing *iframe* before calling `iframe.QueryInterface()`, if *iframe* is falsy, then *toolboxOpened* is never defined, so the `toolboxOpened.catch()` call below will fail.
3. The promise chain will reach the `toolboxOpened.then()` function even if there was an error opening the toolbox, since it gets attached to the chain after `toolboxOpened.catch()`, which doesn't re-throw the error.

Here are fixes for these issues.
