### PR TITLE
make the window object be the global object for modules in renderer processes

### DIFF
--- a/positron/components/ModuleLoader.jsm
+++ b/positron/components/ModuleLoader.jsm
@@ -202,7 +202,7 @@ function ModuleLoader(processType, window) {
   // The `process` global is complicated.  It's implemented by a module,
   // process.js, that we require.  But it's also supposed to exist before any
   // modules are required, since it's a global that's supposed to be available
-  // in all of them.
+  // in all modules.
   //
   // At the moment, we avoid any issue by ensuring that neither process.js
   // nor any module in its dependency chain accesses the `process` global

--- a/positron/components/Process.js
+++ b/positron/components/Process.js
@@ -38,14 +38,52 @@ Process.prototype = {
    */
   init: function(window) {
     let loader = ModuleLoader.getLoaderForWindow(window);
-    this._processGlobal = loader.global.process;
+    this._processGlobal = loader.process;
     return window.processImpl._create(window, this);
   },
 
   /* Node `process` interface */
 
+  get argv() {
+    return this._processGlobal.argv;
+  },
+
+  get env() {
+    return this._processGlobal.env;
+  },
+
+  get execPath() {
+    return this._processGlobal.execPath;
+  },
+
+  get pid() {
+    return this._processGlobal.pid;
+  },
+
+  get platform() {
+    return this._processGlobal.platform;
+  },
+
+  get release() {
+    return this._processGlobal.release;
+  },
+
   get versions() {
     return this._processGlobal.versions;
+  },
+
+  atomBinding(name) {
+    return this._processGlobal.atomBinding(name);
+  },
+
+  binding(name) {
+    return this._processGlobal.binding(name);
+  },
+
+  /* Node `EventEmitter` interface */
+
+  once(name, listener) {
+    return this._processGlobal.once(name, listener);
   },
 
 };

--- a/positron/modules/process.js
+++ b/positron/modules/process.js
@@ -16,8 +16,15 @@ Cu.import('resource://gre/modules/Services.jsm');
 
 const exeFile = Services.dirsvc.get("XREExeF", Ci.nsIFile);
 
-// Re-export `process` as a native module.  I dunno why this matters, since all
-// modules already have access to the global.  But Node does it, so we do too.
+// This file is a special kind of module, as the module loader requires it
+// during loader construction and uses it to define the `process` global.
+// Thus that global is not available at evaluation time, neither for this module
+// nor for any other modules it requires upon evaluation.
+
+const EventEmitter = require('events').EventEmitter;
+const process = new EventEmitter();
+
+
 module.exports = process;
 
 // This is a stub with a placeholder that browser/init.js and renderer/init.js
@@ -100,10 +107,4 @@ process.env = {
   /* stub */
 };
 
-// Make the `process` global into an EventEmitter.  We do this at the end
-// of this script on the off chance that the "events" module ever depends on
-// a property of the `process` global that we define earlier in the script
-// (although it doesn't appear to do so at the moment).
-process.__proto__ = require('events').EventEmitter.prototype;
-
-// ¡¡¡Don't put anything after this line before reading the comment above!!!
+process.type = 'window' in global ? 'renderer' : 'browser';

--- a/positron/modules/process.js
+++ b/positron/modules/process.js
@@ -21,7 +21,7 @@ const exeFile = Services.dirsvc.get("XREExeF", Ci.nsIFile);
 // Thus that global is not available at evaluation time, neither for this module
 // nor for any other modules it requires upon evaluation.
 
-const EventEmitter = require('events').EventEmitter;
+const { EventEmitter } = require('events');
 const process = new EventEmitter();
 
 

--- a/positron/webidl/Process.webidl
+++ b/positron/webidl/Process.webidl
@@ -3,14 +3,36 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+dictionary ReleaseDictionary {
+  DOMString name;
+};
+
 dictionary VersionDictionary {
   DOMString node;
   DOMString chrome;
   DOMString electron;
 };
 
+// EventEmitter isn't instantiated, its methods are just accessed
+// on processImpl.  So it doesn't need a real contract ID.
+[ChromeOnly,
+ JSImplementation="dummy"]
+interface EventEmitter {
+  [Throws]
+  EventEmitter once(DOMString name, Function listener);
+  // TODO: specify the rest of the interface.
+};
+
 [ChromeOnly,
  JSImplementation="@mozilla.org/positron/process;1"]
-interface processImpl {
+interface processImpl : EventEmitter {
+  [Cached, Pure] readonly attribute sequence<DOMString> argv;
+  [Cached, Pure] readonly attribute object env;
+  [Cached, Pure] readonly attribute DOMString execPath;
+  [Cached, Pure] readonly attribute long pid;
+  [Cached, Pure] readonly attribute DOMString platform;
+  [Cached, Pure] readonly attribute ReleaseDictionary release;
   [Cached, Pure] readonly attribute VersionDictionary versions;
+  [Throws] any atomBinding(DOMString name);
+  [Throws] any binding(DOMString name);
 };

--- a/positron/webidl/Process.webidl
+++ b/positron/webidl/Process.webidl
@@ -5,6 +5,10 @@
 
 dictionary ReleaseDictionary {
   DOMString name;
+  // Unimplemented keys that are part of the Node specification:
+  // DOMString sourceUrl;
+  // DOMString headersUrl;
+  // DOMString libUrl; // Windows-only
 };
 
 dictionary VersionDictionary {
@@ -23,6 +27,8 @@ interface EventEmitter {
   // TODO: specify the rest of the interface.
 };
 
+// This currently specifies only a subset of the attributes and operations
+// of the process global as specified by Node.
 [ChromeOnly,
  JSImplementation="@mozilla.org/positron/process;1"]
 interface processImpl : EventEmitter {

--- a/positron/webidl/Process.webidl
+++ b/positron/webidl/Process.webidl
@@ -29,7 +29,7 @@ interface processImpl : EventEmitter {
   [Cached, Pure] readonly attribute sequence<DOMString> argv;
   [Cached, Pure] readonly attribute object env;
   [Cached, Pure] readonly attribute DOMString execPath;
-  [Cached, Pure] readonly attribute long pid;
+  [Cached, Pure] readonly attribute unsigned long pid;
   [Cached, Pure] readonly attribute DOMString platform;
   [Cached, Pure] readonly attribute ReleaseDictionary release;
   [Cached, Pure] readonly attribute VersionDictionary versions;


### PR DESCRIPTION
@marcoscaceres This is another step toward implementing *&lt;webview>*, as the modules that implement it (and the other modules that get loaded in the renderer process) all assume that their global object is the *DOMWindow* object for the renderer window, and they access a variety of *DOMWindow* built-ins on it.

Instead of identifying each individual built-in those modules use and then manually adding them to the global that the *ModuleLoader* creates, this branch makes the *DOMWindow* object itself be the global, so all of its built-ins are available to renderer process modules.

Doing this means that the *process* global for those objects is now the one we bind to *DOMWindow* via WebIDL, and that entrained some changes to the way we expose its properties and methods Basically: we had to explicitly expose them via WebIDL, which we needed to do eventually anyway (in order for the web page itself to have access to them).
