### PR TITLE
Pass args to apply `all` window feature

### DIFF
--- a/positron/components/PositronCLH.js
+++ b/positron/components/PositronCLH.js
@@ -98,7 +98,12 @@ PositronCLH.prototype = {
         if (isLocal(resolvedURI)) {
           // If the URI is local, we are sure it won't wrongly inherit chrome privs
           var features = "chrome,dialog=no,all";
-          Services.ww.openWindow(null, resolvedURI.spec, "_blank", features, null);
+          // For the "all" feature to be applied correctly, you must pass an
+          // args array with at least one element.
+          var args = Components.classes["@mozilla.org/supports-array;1"]
+                               .createInstance(Components.interfaces.nsISupportsArray);
+          args.AppendElement(null);
+          Services.ww.openWindow(null, resolvedURI.spec, "_blank", features, args);
           cmdLine.preventDefault = true;
           return;
         } else {


### PR DESCRIPTION
Instead of #52, we could take this approach to be more like Firefox's behavior.

So, for the "all" feature to apply correctly, `openWindow` must consider you to be a [`dialog`][1], where that is apparently defined as "passed a non-zero length args array".

And sure enough, Firefox's `nsBrowserContentHandler.js` has an [`openWindow`][2] wrapper which seems to create an args array and add at least one element down each of its various paths.

Perhaps it's best to match Firefox since this should enable many [features][3], instead of listing them one by one.

[2]: https://dxr.mozilla.org/mozilla-central/rev/46fe2115d46a5bb40523b8466341d8f9a26e1bdf/browser/components/nsBrowserContentHandler.js#178
[1]: https://dxr.mozilla.org/mozilla-central/rev/46fe2115d46a5bb40523b8466341d8f9a26e1bdf/embedding/components/windowwatcher/nsWindowWatcher.cpp#367
[3]: https://dxr.mozilla.org/mozilla-central/source/embedding/browser/nsIWebBrowserChrome.idl#45-55