### PR TITLE
Resolve window errors when platform debugging

### DIFF
--- a/devtools/server/actors/chrome.js
+++ b/devtools/server/actors/chrome.js
@@ -50,6 +50,13 @@ function ChromeActor(aConnection) {
   if (!window) {
     window = Services.wm.getMostRecentWindow(null);
   }
+
+  // We really want _some_ window at least, so fallback to the hidden window if
+  // there's nothing else (such as during early startup).
+  if (!window) {
+    window = Services.appShell.hiddenDOMWindow;
+  }
+
   // On xpcshell, there is no window/docshell
   let docShell = window ? window.QueryInterface(Ci.nsIInterfaceRequestor)
                                 .getInterface(Ci.nsIDocShell)

--- a/devtools/server/actors/chrome.js
+++ b/devtools/server/actors/chrome.js
@@ -130,9 +130,7 @@ ChromeActor.prototype._attach = function () {
     if (docShell == this.docShell) {
       continue;
     }
-    if (this._progressListener) {
-      this._progressListener.watch(docShell);
-    }
+    this._progressListener.watch(docShell);
   }
 };
 
@@ -155,9 +153,7 @@ ChromeActor.prototype._detach = function () {
     if (docShell == this.docShell) {
       continue;
     }
-    if (this._progressListener) {
-      this._progressListener.unwatch(docShell);
-    }
+    this._progressListener.unwatch(docShell);
   }
 
   TabActor.prototype._detach.call(this);

--- a/devtools/server/actors/webbrowser.js
+++ b/devtools/server/actors/webbrowser.js
@@ -1316,12 +1316,7 @@ TabActor.prototype = {
       // In child processes, we have new root docshells,
       // let's watch them and all their child docshells.
       if (this._isRootDocShell(docShell)) {
-        // Don't assume there's a progress listener, since Positron starts
-        // without a window, so this._progressListener never gets created.
-        // TODO: ensure there's a listener for apps without an initial window.
-        if (this._progressListener) {
-          this._progressListener.watch(docShell);
-        }
+        this._progressListener.watch(docShell);
       }
       this._notifyDocShellsUpdate([docShell]);
     });
@@ -1399,9 +1394,7 @@ TabActor.prototype = {
     // Stop watching this docshell (the unwatch() method will check if we
     // started watching it before).
     webProgress.QueryInterface(Ci.nsIDocShell);
-    if (this._progressListener) {
-      this._progressListener.unwatch(webProgress);
-    }
+    this._progressListener.unwatch(webProgress);
 
     if (webProgress.DOMWindow == this._originalWindow) {
       // If the original top level document we connected to is removed,
@@ -1482,9 +1475,7 @@ TabActor.prototype = {
     // Check for docShell availability, as it can be already gone
     // during Firefox shutdown.
     if (this.docShell) {
-      if (this._progressListener) {
-        this._progressListener.unwatch(this.docShell);
-      }
+      this._progressListener.unwatch(this.docShell);
       this._restoreDocumentSettings();
     }
     if (this._progressListener) {

--- a/positron/app/positron.js
+++ b/positron/app/positron.js
@@ -7,3 +7,4 @@ pref("javascript.options.showInConsole", true);
 pref("devtools.selfxss.count", 5);
 pref("devtools.debugger.remote-enabled", true);
 pref("devtools.chrome.enabled", true);
+pref("devtools.debugger.prompt-connection", false);

--- a/positron/components/Process.js
+++ b/positron/components/Process.js
@@ -37,6 +37,23 @@ Process.prototype = {
    * for an explanation of the behavior of this method.
    */
   init: function(window) {
+    // The WebIDL binding applies to the hidden window too, but we don't want
+    // to initialize the Electron environment for that window, so return early
+    // if we've been called to initialize `process` for that window.
+    //
+    // TODO: restrict the WebIDL binding to windows opened by the Electron app
+    // using the Func extended attribute
+    // <https://developer.mozilla.org/en-US/docs/Mozilla/WebIDL_bindings#Func>.
+    //
+    if (window.location.toString() === 'resource://gre-resources/hiddenWindow.html') {
+      this._processGlobal = new Proxy({}, {
+        get: function(target, name) {
+          window.console.error("'process' not defined in hidden window");
+        }
+      });
+      return window.processImpl._create(window, this);
+    }
+
     let loader = ModuleLoader.getLoaderForWindow(window);
     this._processGlobal = loader.global.process;
     return window.processImpl._create(window, this);

--- a/positron/modules/atom_renderer_ipc.js
+++ b/positron/modules/atom_renderer_ipc.js
@@ -25,7 +25,7 @@ exports.sendSync = function(name, args) {
   // meta protocol used by Electron's RPC server.  This increases the chances we
   // log an error specific to problem site, instead of here at this IPC code.
   if (!result) {
-    result = JSON.stringify({
+    return JSON.stringify({
       type: 'value',
       value: result,
     });

--- a/positron/modules/atom_renderer_ipc.js
+++ b/positron/modules/atom_renderer_ipc.js
@@ -20,5 +20,15 @@ exports.sendSync = function(name, args) {
   // <http://electron.atom.io/docs/api/ipc-renderer/#ipcrenderersendsyncchannel-arg1-arg2->
   // expects to receive a single return value.  So this function returns
   // the first item in the array.
-  return cpmm.sendSyncMessage(name, args, { window })[0];
+  let result = cpmm.sendSyncMessage(name, args, { window })[0];
+  // If no one was listening for the message, wrap up the falsy result in the
+  // meta protocol used by Electron's RPC server.  This increases the chances we
+  // log an error specific to problem site, instead of here at this IPC code.
+  if (!result) {
+    result = JSON.stringify({
+      type: 'value',
+      value: result,
+    });
+  }
+  return result;
 };


### PR DESCRIPTION
I was able to get around the issues from #48 by ensuring we always have a window, and during early startup, we can use the hidden window for that purpose. This allows us to revert the various `_progressListener` guards that were added recently.

Overall the tools are working much better now in the platform debugger. However, I did notice that typing in the console triggers autocompletion that seems to send things over Positron's IPC mechanism, but it fails for some reason. I did not work that part out yet, but added a small debugging aid to improve the error at least. Console evaluation should now be working, so you ignore these autocomplete errors for now.

Fixes #48. @mykmelez, want to take a look?