### PR TITLE
warn once for each stub (fixes #32)

### DIFF
--- a/positron/modules/atom_browser_app.js
+++ b/positron/modules/atom_browser_app.js
@@ -23,7 +23,7 @@ exports.app = {
 };
 
 exports.appendSwitch = positronUtil.makeStub('atom_browser_app.appendSwitch');
-exports.appendArgument = positronUtil.makeStub('atom_browser_app.');
+exports.appendArgument = positronUtil.makeStub('atom_browser_app.appendArgument');
 exports.dockBounce = positronUtil.makeStub('atom_browser_app.dockBounce');
 exports.cancelBounce = positronUtil.makeStub('atom_browser_app.cancelBounce');
 exports.setBadge = positronUtil.makeStub('atom_browser_app.setBadge');

--- a/positron/modules/atom_browser_app.js
+++ b/positron/modules/atom_browser_app.js
@@ -7,6 +7,7 @@
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
 Cu.import('resource://gre/modules/Services.jsm');
+const positronUtil = process.binding('positron_util');
 
 exports.app = {
   quit() {
@@ -21,16 +22,16 @@ exports.app = {
   },
 };
 
-exports.appendSwitch = function() { /* stub */ };
-exports.appendArgument = function() { /* stub */ };
-exports.dockBounce = function() { /* stub */ };
-exports.cancelBounce = function() { /* stub */ };
-exports.setBadge = function() { /* stub */ };
-exports.getBadge = function() { /* stub */ };
-exports.hide = function() { /* stub */ };
-exports.show = function() { /* stub */ };
-exports.setMenu = function() { /* stub */ };
-exports.setIcon = function() { /* stub */ };
+exports.appendSwitch = positronUtil.makeStub('atom_browser_app.appendSwitch');
+exports.appendArgument = positronUtil.makeStub('atom_browser_app.');
+exports.dockBounce = positronUtil.makeStub('atom_browser_app.dockBounce');
+exports.cancelBounce = positronUtil.makeStub('atom_browser_app.cancelBounce');
+exports.setBadge = positronUtil.makeStub('atom_browser_app.setBadge');
+exports.getBadge = positronUtil.makeStub('atom_browser_app.getBadge');
+exports.hide = positronUtil.makeStub('atom_browser_app.hide');
+exports.show = positronUtil.makeStub('atom_browser_app.show');
+exports.setMenu = positronUtil.makeStub('atom_browser_app.setMenu');
+exports.setIcon = positronUtil.makeStub('atom_browser_app.setIcon');
 
 // There isn't currently anything we need to do before emitting app.ready,
 // but apps will expect it to happen after a tick, so emit it in a timeout.

--- a/positron/modules/atom_browser_debugger.js
+++ b/positron/modules/atom_browser_debugger.js
@@ -4,4 +4,6 @@
 
 "use strict";
 
-exports._setWrapDebugger = function() { /* stub */ };
+const positronUtil = process.binding('positron_util');
+
+exports._setWrapDebugger = positronUtil.makeStub('atom_browser_debugger._setWrapDebugger');

--- a/positron/modules/atom_browser_download_item.js
+++ b/positron/modules/atom_browser_download_item.js
@@ -4,4 +4,6 @@
 
 "use strict";
 
-exports._setWrapDownloadItem = function() { /* stub */ };
+const positronUtil = process.binding('positron_util');
+
+exports._setWrapDownloadItem = positronUtil.makeStub('atom_browser_download_item._setWrapDownloadItem');

--- a/positron/modules/atom_browser_menu.js
+++ b/positron/modules/atom_browser_menu.js
@@ -4,6 +4,8 @@
 
 "use strict";
 
-exports.Menu = function() { /* stub */ };
-exports.setApplicationMenu = function() { /* stub */ };
-exports.sendActionToFirstResponder = function() { /* stub */ };
+const positronUtil = process.binding('positron_util');
+
+exports.Menu = positronUtil.makeStub('atom_browser_menu.Menu');
+exports.setApplicationMenu = positronUtil.makeStub('atom_browser_menu.setApplicationMenu');
+exports.sendActionToFirstResponder = positronUtil.makeStub('atom_browser_menu.sendActionToFirstResponder');

--- a/positron/modules/atom_browser_session.js
+++ b/positron/modules/atom_browser_session.js
@@ -4,4 +4,6 @@
 
 "use strict";
 
-exports._setWrapSession = function() { /* stub */ };
+const positronUtil = process.binding('positron_util');
+
+exports._setWrapSession = positronUtil.makeStub('atom_browser_session._setWrapSession');

--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -46,7 +46,7 @@ let WebContents_prototype = {
     this._browserWindow._domWindow.location = url;
   },
 
-  getTitle: positronUtil.makeStub('WebContents.getTitle', ''),
+  getTitle: positronUtil.makeStub('WebContents.getTitle', { returnValue: '' }),
 
   openDevTools() {
     // TODO: When tools can be opened inside the content window, support

--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -6,6 +6,7 @@
 
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 const { Services } = Cu.import("resource://gre/modules/Services.jsm", {});
+const positronUtil = process.binding('positron_util');
 
 let wrapWebContents = null;
 
@@ -45,10 +46,7 @@ let WebContents_prototype = {
     this._browserWindow._domWindow.location = url;
   },
 
-  getTitle: function() {
-    /* stub */
-    return "";
-  },
+  getTitle: positronUtil.makeStub('WebContents.getTitle', ''),
 
   openDevTools() {
     // TODO: When tools can be opened inside the content window, support

--- a/positron/modules/atom_browser_window.js
+++ b/positron/modules/atom_browser_window.js
@@ -67,8 +67,8 @@ function BrowserWindow(options) {
 }
 
 BrowserWindow.prototype = {
-  isVisible: positronUtil.makeStub('BrowserWindow.isVisible', true),
-  isMinimized: positronUtil.makeStub('BrowserWindow.isMinimized', false),
+  isVisible: positronUtil.makeStub('BrowserWindow.isVisible', { returnValue: true }),
+  isMinimized: positronUtil.makeStub('BrowserWindow.isMinimized', { returnValue: false }),
 };
 
 // nsIMessageListener

--- a/positron/modules/atom_browser_window.js
+++ b/positron/modules/atom_browser_window.js
@@ -29,6 +29,7 @@ const windowWatcher = Cc['@mozilla.org/embedcomp/window-watcher;1'].
 
 const WebContents = require('electron').webContents;
 const app = process.atomBinding('app').app;
+const positronUtil = process.binding('positron_util');
 
 const DEFAULT_URL = 'chrome://positron/content/shell.html';
 const DEFAULT_WINDOW_FEATURES = [
@@ -66,15 +67,8 @@ function BrowserWindow(options) {
 }
 
 BrowserWindow.prototype = {
-  isVisible() {
-    /* stub */
-    return true;
-  },
-
-  isMinimized() {
-    /* stub */
-    return false;
-  },
+  isVisible: positronUtil.makeStub('BrowserWindow.isVisible', true),
+  isMinimized: positronUtil.makeStub('BrowserWindow.isMinimized', false),
 };
 
 // nsIMessageListener
@@ -149,4 +143,4 @@ windowWatcher.registerNotification(function observe(subject, topic, data) {
 });
 
 exports.BrowserWindow = BrowserWindow;
-exports._setDeprecatedOptionsCheck = function() { /* stub */ };
+exports._setDeprecatedOptionsCheck = positronUtil.makeStub('atom_browser_window._setDeprecatedOptionsCheck');

--- a/positron/modules/atom_common_v8_util.js
+++ b/positron/modules/atom_common_v8_util.js
@@ -5,8 +5,9 @@
 'use strict';
 
 const util = process.binding('util');
+const positronUtil = process.binding('positron_util');
 
 exports.getHiddenValue = util.getHiddenValue;
 exports.setHiddenValue = util.setHiddenValue;
 
-exports.setDestructor = function(object, callback) { /* stub */ };
+exports.setDestructor = positronUtil.makeStub('atom_common_v8_util.setDestructor');

--- a/positron/modules/atom_renderer_web_frame.js
+++ b/positron/modules/atom_renderer_web_frame.js
@@ -4,4 +4,7 @@
 
 "use strict";
 
-exports.webFrame = { /* stub */ };
+const positronUtil = process.binding('positron_util');
+
+exports.webFrame = {};
+positronUtil.makeStub('atom_renderer_web_frame.webFrame')();

--- a/positron/modules/buffer.js
+++ b/positron/modules/buffer.js
@@ -6,7 +6,8 @@
 
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
-exports.setupBufferJS = function(bufferPrototype, bindingObj) {
-  /* stub */
+const positronUtil = process.binding('positron_util');
+
+exports.setupBufferJS = positronUtil.makeStub('buffer.setupBufferJS', function(bufferPrototype, bindingObj) {
   bindingObj.flags = [];
-};
+});

--- a/positron/modules/buffer.js
+++ b/positron/modules/buffer.js
@@ -8,6 +8,8 @@ const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
 const positronUtil = process.binding('positron_util');
 
-exports.setupBufferJS = positronUtil.makeStub('buffer.setupBufferJS', function(bufferPrototype, bindingObj) {
-  bindingObj.flags = [];
+exports.setupBufferJS = positronUtil.makeStub('buffer.setupBufferJS', { 
+  returnValue: function(bufferPrototype, bindingObj) {
+    bindingObj.flags = [];
+  },
 });

--- a/positron/modules/constants.js
+++ b/positron/modules/constants.js
@@ -6,6 +6,7 @@
 
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
-module.exports = {
-  /* stub */
-};
+const positronUtil = process.binding('positron_util');
+
+module.exports = {};
+positronUtil.makeStub('constants')();

--- a/positron/modules/contextify.js
+++ b/positron/modules/contextify.js
@@ -6,4 +6,6 @@
 
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
-exports.ContextifyScript = function() { /* stub */ };
+const positronUtil = process.binding('positron_util');
+
+exports.ContextifyScript = positronUtil.makeStub('contextify.ContextifyScript');

--- a/positron/modules/fs.js
+++ b/positron/modules/fs.js
@@ -6,4 +6,6 @@
 
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
-exports.FSInitialize = function() { /* stub */ };
+const positronUtil = process.binding('positron_util');
+
+exports.FSInitialize = positronUtil.makeStub('fs.FSInitialize');

--- a/positron/modules/fs_event_wrap.js
+++ b/positron/modules/fs_event_wrap.js
@@ -6,4 +6,6 @@
 
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
-exports.FSEvent = function() { /* stub */ };
+const positronUtil = process.binding('positron_util');
+
+exports.FSEvent = positronUtil.makeStub('fs_event_wrap.FSEvent');

--- a/positron/modules/moz.build
+++ b/positron/modules/moz.build
@@ -19,6 +19,7 @@ EXTRA_JS_MODULES.gecko += [
   'contextify.js',
   'fs.js',
   'fs_event_wrap.js',
+  'positron_util.js',
   'process.js',
   'timer_wrap.js',
   'util.js',

--- a/positron/modules/positron_util.js
+++ b/positron/modules/positron_util.js
@@ -6,7 +6,7 @@
 
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
-exports.makeStub = function(signature, returnValue) {
+exports.makeStub = function(signature, { returnValue } = {}) {
   let doNotWarn;
 
   if (typeof returnValue === "function") {

--- a/positron/modules/positron_util.js
+++ b/positron/modules/positron_util.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
+
+exports.makeStub = function(signature, returnValue) {
+  let doNotWarn;
+
+  if (typeof returnValue === "function") {
+    doNotWarn = returnValue;
+  } else {
+    doNotWarn = function() { return returnValue };
+  }
+
+  let warnOnce = function() {
+    console.warn(signature + ' not implemented');
+    warnOnce = doNotWarn;
+    return doNotWarn.apply(this, arguments);
+  }
+
+  return function() {
+    return warnOnce.apply(this, arguments);
+  }
+};

--- a/positron/modules/process.js
+++ b/positron/modules/process.js
@@ -78,6 +78,8 @@ process.binding = function(name) {
   return require(`resource:///modules/gecko/${name}.js`);
 }
 
+const positronUtil = process.binding('positron_util');
+
 process.execPath = exeFile.path;
 
 // Per <https://nodejs.org/api/process.html#process_process_platform>,
@@ -103,8 +105,7 @@ Object.defineProperty(process, 'pid', {
 
 // We might be able to implement this by using nsIEnvironment, although that API
 // doesn't provide enumeration, whereas this one presumably does.
-process.env = {
-  /* stub */
-};
+process.env = {};
+positronUtil.makeStub('process.env')();
 
 process.type = 'window' in global ? 'renderer' : 'browser';

--- a/positron/modules/timer_wrap.js
+++ b/positron/modules/timer_wrap.js
@@ -6,4 +6,6 @@
 
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
-exports.Timer = function() { /* stub */ };
+const positronUtil = process.binding('positron_util');
+
+exports.Timer = positronUtil.makeStub('timer_wrap.Timer');


### PR DESCRIPTION
This fixes #32 by adding _positronUtil.makeStub()_, which makes a "stub function" that warns the first time it's called, and then replacing all `function() { /* stub */ }` occurrences with functions created by *makeStub()*.

Modules that are themselves stubs call *makeStub()()* to make a stub function and then immediately call it to output a warning (so we see the warning when the module is first evaluated).

Stub functions that need to return a value pass the return value to *makeStub()*, which then returns it each time the stub is called (although it still only warns once). Stubs that need to generate a return value (or do something else when the stub is called) pass a function argument for the *returnValue* property, which the "warn once" function will then call to generate the return value.

This is essentially the same as [addUnimplementedNative() from PluotSorbet](https://github.com/mozilla/pluotsorbet/blob/16cc4934a4a1dcfeeb2ccc5102aa5cfec768370d/native.js#L783-L799), except for a project-specific detail (it returns the stub instead of assigning it to a global map of stubs, since there is no such global map in Positron). Plus, _let_ is the new _var_.

@marcoscaceres How does this look to you?
