### PR TITLE
construct a module loader for every chrome window

### DIFF
--- a/positron/components/Process.js
+++ b/positron/components/Process.js
@@ -20,6 +20,7 @@ Cu.import('resource:///modules/ModuleLoader.jsm');
 function Process() {}
 
 Process.prototype = {
+  _contentWindow: null,
   _processGlobal: null,
 
   classID: Components.ID('{3c81d709-5fb4-4144-9612-9ecc1be4e7b1}'),
@@ -37,6 +38,8 @@ Process.prototype = {
    * for an explanation of the behavior of this method.
    */
   init: function(window) {
+    this._contentWindow = window;
+
     // The WebIDL binding applies to the hidden window too, but we don't want
     // to initialize the Electron environment for that window, so return early
     // if we've been called to initialize `process` for that window.
@@ -85,6 +88,10 @@ Process.prototype = {
     return this._processGlobal.release;
   },
 
+  get type() {
+    return this._processGlobal.type;
+  },
+
   get versions() {
     return this._processGlobal.versions;
   },
@@ -94,7 +101,17 @@ Process.prototype = {
   },
 
   binding(name) {
-    return this._processGlobal.binding(name);
+    try {
+      return this._processGlobal.binding(name);
+    } catch(ex) {
+      // Per
+      // https://developer.mozilla.org/en-US/docs/Mozilla/WebIDL_bindings#Throwing_exceptions_from_JS-implemented_APIs
+      // we need to recreate Error objects via our own content window,
+      // or the WebIDL binding will set its message to "NS_ERROR_UNEXPECTED",
+      // which will fail the `/No such module/.test(error.message)` check
+      // in common/init.js.
+      throw new this._contentWindow.Error(ex.message);
+    }
   },
 
   /* Node `EventEmitter` interface */

--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -43,7 +43,7 @@ let WebContents_prototype = {
   },
 
   loadURL: function(url) {
-    this._browserWindow._domWindow.location = url;
+    this._browserWindow._loadURL(url);
   },
 
   getTitle: positronUtil.makeStub('WebContents.getTitle', { returnValue: '' }),

--- a/positron/modules/atom_browser_window.js
+++ b/positron/modules/atom_browser_window.js
@@ -27,6 +27,9 @@ const ppmm = Cc['@mozilla.org/parentprocessmessagemanager;1'].
 const windowWatcher = Cc['@mozilla.org/embedcomp/window-watcher;1'].
                       getService(Ci.nsIWindowWatcher);
 
+Cu.import('resource://gre/modules/Services.jsm');
+Cu.import('resource:///modules/ModuleLoader.jsm');
+
 const WebContents = require('electron').webContents;
 const app = process.atomBinding('app').app;
 const positronUtil = process.binding('positron_util');
@@ -69,6 +72,32 @@ function BrowserWindow(options) {
 BrowserWindow.prototype = {
   isVisible: positronUtil.makeStub('BrowserWindow.isVisible', { returnValue: true }),
   isMinimized: positronUtil.makeStub('BrowserWindow.isMinimized', { returnValue: false }),
+
+  _loadURL: function(url) {
+    // Observe document-element-inserted and eagerly create the module loader,
+    // so <webview> is available by the time the document loads.
+    const observer = {
+      observe: (subject, topic, data) => {
+        // Although we add this observer right before loading the URL
+        // (and remove it right afterward), we're still notified asynchronously
+        // about the insertion, and we might get notified about others
+        // in the meantime, so we need to confirm that the document in question
+        // is ours.
+        if (subject.defaultView !== this._domWindow) {
+          return;
+        }
+
+        Services.obs.removeObserver(observer, 'document-element-inserted');
+
+        // Ignore the return value, since we're only calling getLoaderForWindow
+        // for its side-effect of creating a new loader for the window.
+        ModuleLoader.getLoaderForWindow(subject.defaultView);
+      },
+    };
+    Services.obs.addObserver(observer, 'document-element-inserted', false);
+
+    this._domWindow.location = url;
+  },
 };
 
 // nsIMessageListener

--- a/positron/modules/process.js
+++ b/positron/modules/process.js
@@ -36,14 +36,12 @@ process.argv = [exeFile.leafName, "placeholder that init.js removes"];
 // this module, so we construct the `process` global by importing this module
 // rather than the other way around.
 
-// Because we construct the `process` global in this module, and we also inject
-// the global into this module, we don't actually have to export its symbols
-// here.  We just have to attach them to this module's own `process` global.
-// XXX Figure out if that's really the best way to implement this functionality.
-
 // This comes from Electron, where it's defined by common/init.js, which we
-// currently don't load.  Once we enable loading of init.js modules, we should
-// remove it from this module.
+// currently don't load in the main process (although we do load it in renderer
+// processes, so the version in init.js overrides this one in those processes).
+//
+// TODO: once we enable the loading of init.js in the main process, remove this.
+//
 process.atomBinding = function(name) {
   try {
     return process.binding("atom_" + process.type + "_" + name);

--- a/positron/webidl/Process.webidl
+++ b/positron/webidl/Process.webidl
@@ -38,7 +38,8 @@ interface processImpl : EventEmitter {
   [Cached, Pure] readonly attribute unsigned long pid;
   [Cached, Pure] readonly attribute DOMString platform;
   [Cached, Pure] readonly attribute ReleaseDictionary release;
+  [Cached, Pure] readonly attribute DOMString type;
   [Cached, Pure] readonly attribute VersionDictionary versions;
-  [Throws] any atomBinding(DOMString name);
-  [Throws] any binding(DOMString name);
+  any atomBinding(DOMString name);
+  any binding(DOMString name);
 };


### PR DESCRIPTION
@brendandahl Now that you're hacking in Positron, perhaps you can review this change?  It's a prerequisite to supporting the sample browser app.

Currently, a _ModuleLoader_ is created for a _BrowserWindow_ when the _process_ global is accessed in the window. That's fine for the "hello world" app, which accesses that global. But the sample browser doesn't access _process_, and _process_ is actually lazily instantiated, which means that we don't currently create a _ModuleLoader_ for the sample browser's _BrowserWindow_.

And since the &lt;webview> element is initialized by Electron's web-view.js module, which gets loaded by the _ModuleLoader_, that means there's no &lt;webview> in the sample browser. Making the _process_ global create the _ModuleLoader_ was always a hack that we needed to fix eventually; it just so happens that eventually is now.

This branch instead creates the _ModuleLoader_ on `document-element-inserted`, which is **before** the document's script is executed (and any &lt;webview> elements inserted) and unconditional. Along the way, it fixes up the WebIDL binding for the _process_ global in three ways:

1. Removes the `[Throws]` attribute from the _binding_ and _atomBinding_ method declarations, per https://developer.mozilla.org/en-US/docs/Mozilla/WebIDL_bindings#Throws, which says, "For interfaces flagged with [JSImplementation], all methods and properties are assumed to be able to throw and do not need to be flagged as throwing."
2. Recreates the error thrown by _process.binding_, per the comments in the code about needing to do that in order to preserve its message.
3. Defines _process.type_ in the WebIDL binding, as it can be called via the binding.
