### PR TITLE
give a document loaded in a top-level docshell the system principal

### DIFF
--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -2137,8 +2137,16 @@ nsDocument::Reset(nsIChannel* aChannel, nsILoadGroup* aLoadGroup)
     nsIScriptSecurityManager *securityManager =
       nsContentUtils::GetSecurityManager();
     if (securityManager) {
-      securityManager->GetChannelResultPrincipal(aChannel,
-                                                 getter_AddRefs(principal));
+      nsCOMPtr<nsIDocShell> docShell(mDocumentContainer);
+      nsCOMPtr<nsIDocShellTreeItem> parentDocShellTreeItem;
+      if (docShell && NS_SUCCEEDED(docShell->GetParent(getter_AddRefs(parentDocShellTreeItem))) &&
+          !parentDocShellTreeItem)
+      {
+        securityManager->GetSystemPrincipal(getter_AddRefs(principal));
+      } else {
+        securityManager->GetChannelResultPrincipal(aChannel,
+                                                   getter_AddRefs(principal));
+      }
     }
   }
 

--- a/positron/app/positron.js
+++ b/positron/app/positron.js
@@ -8,3 +8,4 @@ pref("devtools.selfxss.count", 5);
 pref("devtools.debugger.remote-enabled", true);
 pref("devtools.chrome.enabled", true);
 pref("devtools.debugger.prompt-connection", false);
+pref("dom.mozBrowserFramesEnabled", true);

--- a/positron/test/hello-world/index.html
+++ b/positron/test/hello-world/index.html
@@ -9,5 +9,7 @@
     We are using node <script>document.write(process.versions.node)</script>,
     Chromium <script>document.write(process.versions.chrome)</script>,
     and Electron <script>document.write(process.versions.electron)</script>.
+
+    <iframe mozbrowser="true" remote="true" src="https://mozilla.org/"></iframe>
   </body>
 </html>


### PR DESCRIPTION
@brendandahl This seems to make the HTML document loaded by the sample browser into the top-level window of a BrowserWindow have a system principal on the webview-element branch. It breaks something else, though, since the initial URL no longer loads in the mozbrowser.
