### PR TITLE
include SpecialSystemDirectory.h to resolve build bustage

### DIFF
--- a/toolkit/xre/nsXREDirProvider.cpp
+++ b/toolkit/xre/nsXREDirProvider.cpp
@@ -25,6 +25,7 @@
 #include "nsDirectoryServiceUtils.h"
 #include "nsXULAppAPI.h"
 #include "nsCategoryManagerUtils.h"
+#include "SpecialSystemDirectory.h"
 
 #include "nsINIParser.h"
 #include "nsDependentString.h"


### PR DESCRIPTION
[Bug 1270356](https://bugzilla.mozilla.org/show_bug.cgi?id=1270356) adds a reference to GetOSXFolderType into nsXREDirProvider.cpp, which busts the build with:

```
In file included from /Users/myk/Projects/positron/obj-x86_64-apple-darwin14.5.0/toolkit/xre/Unified_cpp_toolkit_xre0.cpp:56:
/Users/myk/Projects/positron/toolkit/xre/nsXREDirProvider.cpp:257:8: error: use of undeclared identifier 'GetOSXFolderType'; did you mean 'GetFolderTypes'?
  rv = GetOSXFolderType(kOnSystemDisk, kApplicationSupportFolderType, getter_AddRefs(localDir));
       ^~~~~~~~~~~~~~~~
       GetFolderTypes
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Folders.h:745:1: note: 'GetFolderTypes' declared here
GetFolderTypes(
^
In file included from /Users/myk/Projects/positron/obj-x86_64-apple-darwin14.5.0/toolkit/xre/Unified_cpp_toolkit_xre0.cpp:56:
/Users/myk/Projects/positron/toolkit/xre/nsXREDirProvider.cpp:257:40: error: cannot initialize a parameter of type 'UInt32 *' (aka 'unsigned int *') with an rvalue of type '(anonymous enum at /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Folders.h:426:1)'
  rv = GetOSXFolderType(kOnSystemDisk, kApplicationSupportFolderType, getter_AddRefs(localDir));
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Folders.h:747:17: note: passing argument to parameter 'totalTypeCount' here
  UInt32 *      totalTypeCount,
                ^
2 errors generated.
```

Strangely, Firefox builds fine, which is presumably why the change doesn't cause bustage in mozilla-central automation. Here's the trivial fix, which I'll push upstream.
