### PR TITLE
Default app

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ We're actively working on this, so if you're interested in the status of this pr
 ### How to build
 Before building please make sure you have the prerequisites for building Firefox as documented [here](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_build#Build_prerequisites).
 
-You need to add the following line to your mozconfig file:
-```
-ac_add_options --enable-application=positron
-```
-
 Build Command:
 ```bash
 ./mach build

--- a/build/moz.configure/init.configure
+++ b/build/moz.configure/init.configure
@@ -606,7 +606,7 @@ imply_option('--enable-project', application)
 def default_project(build_env, help):
     if build_env.topobjdir.endswith('/js/src'):
         return 'js'
-    return 'browser'
+    return 'positron'
 
 option('--enable-project', nargs=1, default=default_project,
        help='Project to build')


### PR DESCRIPTION
This makes Positron the default app, so you don't have to create a .mozconfig file to build it. That simplifies build instructions, which is handy for folks who are less familiar with Mozilla's build system. In particular, with this change, I can tell people to simply cut and paste a block of text into a terminal to get, build, and test Positron:

>git clone https://github.com/mozilla/positron
>cd positron
>./mach build
>./mach run positron/test/hello-world/

Whereas before I had to tell them to enable the app in .mozconfig, making it more cumbersome to follow the instructions, because they're no longer copy/pastable in one fell swoop:

>git clone https://github.com/mozilla/positron
>cd positron
>\# Now enable the app in .mozconfig: ac_add_options --enable-application=positron
>./mach build
>./mach run positron/test/hello-world/

