### PR TITLE
don't assume the webview has a content document

### DIFF
--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -135,7 +135,7 @@ const GuestWebContentsPrototype = {
   isGuest() { return true },
 
   getURL: function() {
-    if (this._webView) {
+    if (this._webView && this._webView.browserPluginNode.contentDocument) {
       return this._webView.browserPluginNode.contentDocument.URL;
     }
     console.warn('cannot get URL for guest WebContents');


### PR DESCRIPTION
The &lt;webview> isn't guaranteed to have a content document, so we should ensure it does before trying to get its URL.