### PR TITLE
Ensure remote iframes don't get the system principal.

### DIFF
--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -2157,6 +2157,7 @@ nsDocument::Reset(nsIChannel* aChannel, nsILoadGroup* aLoadGroup)
       nsCOMPtr<nsIDocShell> docShell(mDocumentContainer);
       nsCOMPtr<nsIDocShellTreeItem> parentDocShellTreeItem;
       if (docShell &&
+          docShell->ItemType() == nsIDocShellTreeItem::typeChrome &&
           NS_SUCCEEDED(docShell->GetParent(getter_AddRefs(parentDocShellTreeItem))) &&
           !parentDocShellTreeItem)
       {

--- a/positron/electron/lib/renderer/web-view/web-view.js
+++ b/positron/electron/lib/renderer/web-view/web-view.js
@@ -295,7 +295,7 @@ var registerBrowserPluginElement = function() {
 
     // This breaks loading a page in the mozbrowser when we give the app page
     // the system principal, so we've temporarily disabled it.
-    // this.setAttribute('remote', 'true');
+    this.setAttribute('remote', 'true');
 
     this.addEventListener('mozbrowserloadstart', function(event) {
       var internal;


### PR DESCRIPTION
After some careful log review of remote=true/false, I saw that there were some NS_FAILED that'd didn't occur on remote=false. After checking those out, I tracked the failure down to https://github.com/mozilla/gecko-dev/blob/965dbc5745f2dd40106a3e075ab8d3ef284c0aa6/caps/nsSystemPrincipal.cpp#L73

Turns out our hack to give system principal to the top document was also giving it to the remote iframe.