### PR TITLE
reuse sandbox for main process

### DIFF
--- a/positron/electron/lib/browser/rpc-server.js
+++ b/positron/electron/lib/browser/rpc-server.js
@@ -46,12 +46,6 @@ let getObjectPrototype = function(object) {
   if (proto === null || proto === Object.prototype)
     return null;
 
-  // This hack employs duck typing to compare `proto` to `Object.prototype`
-  // to work around cases in which the objects are from different sandboxes.
-  // XXX Implement a real fix for that issue and remove this hack.
-  if (Object.keys(proto).sort().join('') === Object.keys(Object.prototype).sort().join(''))
-    return null;
-
   return {
     members: getObjectMembers(proto),
     proto: getObjectPrototype(proto),

--- a/positron/modules/process.js
+++ b/positron/modules/process.js
@@ -9,8 +9,6 @@ const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 // The Node version of this module only re-exports the `process` global,
 // because the global is implemented natively.  But we implement the global
 // in this file, which is the first module required by the ModuleLoader.
-// Because `process` is already defined, we don't need to construct it, so we
-// simply populate it.
 
 Cu.import('resource://gre/modules/Services.jsm');
 


### PR DESCRIPTION
This is a partial fix for #45 that coalesces sandboxes for the main process, reusing a single sandbox for all modules loaded in that process, so globals like *Object* return the expected results in cross-module equality comparisons. In the process, it removes the "duck typing" workaround that we landed in #26.

Sandbox coalescing for renderer processes still doesn't work, and I'm not sure why, but I've described the issue in #93, and this branch continues to use discrete sandboxes for each module loaded in that process.

I also updated some commentary and un-refactored *injectModuleGlobals*, which is only called at one site, and which is mis-named in any case.

@brendandahl How does this look to you?
