### PR TITLE
Track the url of remote iframes.

### DIFF
--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -128,18 +128,20 @@ const BrowserWindowWebContentsPrototype = {
 
 const GuestWebContentsPrototype = {
   _webView: null,
+  _url: null,
   attachWebViewToGuest(webView) {
     this._webView = webView;
+
+    let onBrowserLocationChange = (e) => {
+      this._url = e.detail;
+    };
+    this._webView.browserPluginNode.addEventListener("mozbrowserlocationchange", onBrowserLocationChange);
   },
 
   isGuest() { return true },
 
   getURL: function() {
-    if (this._webView && this._webView.browserPluginNode.contentDocument) {
-      return this._webView.browserPluginNode.contentDocument.URL;
-    }
-    console.warn('cannot get URL for guest WebContents');
-    return null;
+    return this._url;
   },
 
   loadURL: function(url) {


### PR DESCRIPTION
The sample browser app still leaves a bit to be desired, but it seems to also have issues with electron as well (I see "undefined" flashed in the url bar when loading and changing pages).

Fixes #92