### PR TITLE
Load modules in their own scopes with evalInSandbox.

### DIFF
--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -255,6 +255,7 @@ function WebContents(options) {
   }
 
   this._getURL = this.getURL;
+  this._loadURL = this.loadURL;
 }
 
 exports.create = function(options) {


### PR DESCRIPTION
Fixes #93 an #45

This solution doesn't seem quite as clean as using the built in loadSubScript and I  wonder about the performance implications of loading the entire script into a string and evaling it.

We could instead try to fix the DOM bindings issue I mentioned in https://github.com/mozilla/positron/issues/45#issuecomment-228914035

Thoughts?