### PR TITLE
hide iframe border that Gecko adds by default

### DIFF
--- a/positron/electron/lib/renderer/web-view/web-view.js
+++ b/positron/electron/lib/renderer/web-view/web-view.js
@@ -359,6 +359,12 @@ var registerBrowserPluginElement = function() {
                        event, 'did-fail-load');
     }, false);
 
+    // Hide the border that Gecko adds by default.  Apps that want a border
+    // around the <webview> element can add one to the <webview> element itself.
+    // This iframe is an internal implementation detail, so it shouldn't express
+    // visible style.
+    this.style.border = '0';
+
     // The <iframe> node fills in the <webview> container.
     return this.style.flex = '1 1 auto';
   };


### PR DESCRIPTION
This doesn't manifest in the sample browser, strangely, perhaps because it applies some style rule to the iframe, but the &lt;iframe mozbrowser> in the shadow DOM of the &lt;webview> element is surrounded by a 2px border when a &lt;webview> is placed into a simple app without any other styling.

And since the &lt;iframe> is an internal implementation detail, it shouldn't express visible style. Apps that want a border around the &lt;webview> can always add one themselves. (Electron doesn't display such a border by default, so this change also improves Electron compatibility.)