### PR TITLE
replace .taskcluster.yml file with Positron-specific version

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,116 +1,31 @@
----
 version: 0
 metadata:
-  name: 'Taskcluster tasks for Gecko'
-  description: "The taskcluster task graph for Gecko trees"
-  owner: mozilla-taskcluster-maintenance@mozilla.com
-  source: {{{source}}}
-
-scopes:
-  # Note the below scopes are insecure however these get overriden on the server
-  # side to whatever scopes are set by mozilla-taskcluster.
-  - queue:*
-  - docker-worker:*
-  - scheduler:*
-
-# Available mustache parameters (see the mozilla-taskcluster source):
-#
-# - owner:          push user (email address)
-# - source:         URL of this YAML file
-# - url:            repository URL
-# - project:        alias for the destination repository (basename of
-#                   the repo url)
-# - level:          SCM level of the destination repository
-#                   (1 = try, 3 = core)
-# - revision:       (short) hg revision of the head of the push
-# - revision_hash:  (long) hg revision of the head of the push
-# - comment:        comment of the push
-# - pushlog_id:     id in the pushlog table of the repository
-#
-# and functions:
-# - as_slugid:      convert a label into a slugId
-# - from_now:       generate a timestamp at a fixed offset from now
-
+    name: "Positron"
+    description: "continuous integration for Positron"
+    owner: "{{ event.head.user.email }}"
+    source: "{{ event.head.repo.url }}"
 tasks:
-  - taskId: '{{#as_slugid}}decision task{{/as_slugid}}'
-    task:
-      created: '{{now}}'
-      deadline: '{{#from_now}}1 day{{/from_now}}'
-      expires: '{{#from_now}}14 day{{/from_now}}'
-      metadata:
-        owner: mozilla-taskcluster-maintenance@mozilla.com
-        source: {{{source}}}
-        name: "Gecko Decision Task"
-        description: |
-            The task that creates all of the other tasks in the task graph
-
-      workerType: "gecko-decision"
-      provisionerId: "aws-provisioner-v1"
-
-      tags:
-        createdForUser: {{owner}}
-
-      scopes:
-        # Bug 1269443: cache scopes, etc. must be listed explicitly
-        - "docker-worker:cache:level-{{level}}-*"
-        - "docker-worker:cache:tooltool-cache"
-        - "secrets:get:project/taskcluster/gecko/hgfingerprint"
-        # mozilla-taskcluster will append the appropriate assume:repo:<repo>
-        # scope here.
-
-      routes:
-        - "index.gecko.v2.{{project}}.latest.firefox.decision"
-        - "tc-treeherder.v2.{{project}}.{{revision}}.{{pushlog_id}}"
-        - "tc-treeherder-stage.v2.{{project}}.{{revision}}.{{pushlog_id}}"
-
-      payload:
-        env:
-          # checkout-gecko uses these to check out the source; the inputs
-          # to `mach taskgraph decision` are all on the command line.
-          GECKO_BASE_REPOSITORY: 'https://hg.mozilla.org/mozilla-central'
-          GECKO_HEAD_REPOSITORY: '{{{url}}}'
-          GECKO_HEAD_REF: '{{revision}}'
-          GECKO_HEAD_REV: '{{revision}}'
-
-        cache:
-          level-{{level}}-{{project}}-tc-vcs-public-sources: /home/worker/.tc-vcs/
-          level-{{level}}-{{project}}-gecko-decision: /home/worker/workspace
-
-        features:
-          taskclusterProxy: true
-
-        # Note: This task is built server side without the context or tooling that
-        # exist in tree so we must hard code the version
-        image: 'taskcluster/decision:0.1.0'
-
-        maxRunTime: 1800
-
-        command:
-          - /bin/bash
-          - -cx
-          - >
-            mkdir -p /home/worker/artifacts &&
-            checkout-gecko workspace &&
-            cd workspace/gecko &&
-            ln -s /home/worker/artifacts artifacts &&
-            ./mach taskgraph decision
-            --pushlog-id='{{pushlog_id}}'
-            --project='{{project}}'
-            --message='{{comment}}'
-            --owner='{{owner}}'
-            --level='{{level}}'
-            --base-repository='https://hg.mozilla.org/mozilla-central'
-            --head-repository='{{{url}}}'
-            --head-ref='{{revision}}'
-            --head-rev='{{revision}}'
-            --revision-hash='{{revision_hash}}'
-
-        artifacts:
-          'public':
-            type: 'directory'
-            path: '/home/worker/artifacts'
-            expires: '{{#from_now}}7 days{{/from_now}}'
-
+    - provisionerId: "{{ taskcluster.docker.provisionerId }}"
+      workerType: "{{ taskcluster.docker.workerType }}"
       extra:
-        treeherder:
-          symbol: D
+          github:
+              env: true
+              events:
+                  - pull_request.opened
+                  - pull_request.synchronize
+                  - pull_request.reopened
+                  - push
+      payload:
+          maxRunTime: 7200 # seconds (i.e. two hours)
+          image: "mykmelez/docker-build-positron:latest"
+          command:
+              - "/bin/bash"
+              - "--login"
+              - "-c"
+              - "tc-vcs checkout repo https://github.com/mozilla/gecko-dev $GITHUB_HEAD_REPO_URL $GITHUB_HEAD_BRANCH &&
+                 cd repo/ && SHELL=/bin/bash ./mach build"
+      metadata:
+          name: "checkoutandbuild"
+          description: "check out and build the repository"
+          owner: "{{ event.head.user.email }}"
+          source: "{{ event.head.repo.url }}"


### PR DESCRIPTION
This branch uses TaskCluster's support for GitHub to add continuous integration to Positron. Currently, it just builds the app, and TaskCluster reports the result via a comment on each change (or changeset) as well as an annotation on each pull request (I think; will know for sure once I create this pull request). In the future, we should be able to add tasks that run tests as well, once we have tests running.

This is essentially a wholesale replacement of the existing .taskcluster.yml file in the top-level of mozilla-central, so the [whole file view](https://github.com/mozilla/positron/blob/d84e9b0d9e6bd42d255d70a95bbd83608d783e04/.taskcluster.yml) is a better read than the default diff view. Unfortunately, we have to overload that file (and resolve spurious conflicts when merging from upstream) because it's the only file TaskCluster can inspect to determine whether and which tasks to run. But it also doesn't get updated very often (per [its history](https://github.com/mozilla/gecko-dev/commits/master/.taskcluster.yml)), so I don't anticipate many merge conflicts.

The build environment is this [naive Docker image)(https://hub.docker.com/r/mykmelez/docker-build-positron/) from [this Dockerfile](https://github.com/mykmelez/docker-build-positron/blob/master/Dockerfile) that is based on Ubuntu 14.04 (Trusty), installs [taskcluster-vcs](https://www.npmjs.com/package/taskcluster-vcs) to pull partly from TaskCluster caches, and uses mozilla-central's bootstrap.py to install build dependencies. (There are undoubtedly many ways to improve this environment, but it should suffice for the time being.)

Oh, and: I developed this in the taskcluster-yml branch in https://github.com/mozilla/positron instead of my https://github.com/mykmelez/positron personal fork because TaskCluster only runs for projects in the "mozilla" org. That's a downside of TaskCluster, relative to CI services like Travis and CircleCI, which you can configure to build your personal repo. But, on the plus side, TaskCluster supports all three primary desktop OSes, and it doesn't impose time limits that are too short for Positron and other Mozilla apps. I'm unsure what this means for CI of pull requests from personal forks.
