### PR TITLE
enable mozbrowser API for specific origins

### DIFF
--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -5969,6 +5969,41 @@ nsDocument::IsWebComponentsEnabled(JSContext* aCx, JSObject* aObject)
   return false;
 }
 
+bool
+nsDocument::IsBrowserElementEnabled(JSContext* aCx, JSObject* aObject)
+{
+  JS::Rooted<JSObject*> obj(aCx, aObject);
+
+  if (!Preferences::GetBool("dom.mozBrowserFramesEnabled")) {
+    return false;
+  }
+
+  if (nsContentUtils::IsCallerChrome()) {
+    return true;
+  }
+
+  // Check for the webcomponents permission. See Bug 1181555.
+  JSAutoCompartment ac(aCx, obj);
+  JS::Rooted<JSObject*> global(aCx, JS_GetGlobalForObject(aCx, obj));
+  nsCOMPtr<nsPIDOMWindowInner> window =
+    do_QueryInterface(nsJSUtils::GetStaticScriptGlobal(global));
+
+  if (window) {
+    nsresult rv;
+    nsCOMPtr<nsIPermissionManager> permMgr =
+      do_GetService(NS_PERMISSIONMANAGER_CONTRACTID, &rv);
+    NS_ENSURE_SUCCESS(rv, false);
+
+    uint32_t perm;
+    rv = permMgr->TestPermissionFromWindow(window, "browser", &perm);
+    NS_ENSURE_SUCCESS(rv, false);
+
+    return perm == nsIPermissionManager::ALLOW_ACTION;
+  }
+
+  return false;
+}
+
 nsresult
 nsDocument::RegisterUnresolvedElement(Element* aElement, nsIAtom* aTypeName)
 {

--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -2116,25 +2116,8 @@ nsDocument::Reset(nsIChannel* aChannel, nsILoadGroup* aLoadGroup)
     nsIScriptSecurityManager *securityManager =
       nsContentUtils::GetSecurityManager();
     if (securityManager) {
-      // Give loads in top-level docshells the system principal so Positron
-      // can give chrome privileges to application documents that it loads
-      // into chrome windows from file: URLs.
-      //
-      // TODO: figure out a better way to give those documents this principal.
-      // https://github.com/mozilla/positron/issues/67
-      //
-      nsCOMPtr<nsIDocShell> docShell(mDocumentContainer);
-      nsCOMPtr<nsIDocShellTreeItem> parentDocShellTreeItem;
-      if (docShell &&
-          docShell->ItemType() == nsIDocShellTreeItem::typeChrome &&
-          NS_SUCCEEDED(docShell->GetParent(getter_AddRefs(parentDocShellTreeItem))) &&
-          !parentDocShellTreeItem)
-      {
-        securityManager->GetSystemPrincipal(getter_AddRefs(principal));
-      } else {
-        securityManager->GetChannelResultPrincipal(aChannel,
-                                                   getter_AddRefs(principal));
-      }
+      securityManager->GetChannelResultPrincipal(aChannel,
+                                                 getter_AddRefs(principal));
     }
   }
 

--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -5982,7 +5982,11 @@ nsDocument::IsBrowserElementEnabled(JSContext* aCx, JSObject* aObject)
     return true;
   }
 
-  // Check for the webcomponents permission. See Bug 1181555.
+  if (!Preferences::GetBool("dom.mozBrowserFramesEnabledForContent")) {
+    return false;
+  }
+
+  // Check for the browser permission.
   JSAutoCompartment ac(aCx, obj);
   JS::Rooted<JSObject*> global(aCx, JS_GetGlobalForObject(aCx, obj));
   nsCOMPtr<nsPIDOMWindowInner> window =

--- a/dom/base/nsDocument.h
+++ b/dom/base/nsDocument.h
@@ -1540,6 +1540,7 @@ public:
                                   const nsAString* aTypeExtension) override;
 
   static bool IsWebComponentsEnabled(JSContext* aCx, JSObject* aObject);
+  static bool IsBrowserElementEnabled(JSContext* aCx, JSObject* aObject);
 
   // The "registry" from the web components spec.
   RefPtr<mozilla::dom::Registry> mRegistry;

--- a/dom/webidl/BrowserElement.webidl
+++ b/dom/webidl/BrowserElement.webidl
@@ -30,32 +30,32 @@ BrowserElement implements BrowserElementPrivileged;
 interface BrowserElementCommon {
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void setVisible(boolean visible);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest getVisible();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void setActive(boolean active);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   boolean getActive();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void addNextPaintListener(BrowserElementNextPaintEventCallback listener);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void removeNextPaintListener(BrowserElementNextPaintEventCallback listener);
 };
 
@@ -63,7 +63,7 @@ interface BrowserElementCommon {
 interface BrowserElementPrivileged {
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void sendMouseEvent(DOMString type,
                       unsigned long x,
                       unsigned long y,
@@ -74,7 +74,7 @@ interface BrowserElementPrivileged {
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    Func="TouchEvent::PrefEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void sendTouchEvent(DOMString type,
                       sequence<unsigned long> identifiers,
                       sequence<long> x,
@@ -88,96 +88,96 @@ interface BrowserElementPrivileged {
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void goBack();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void goForward();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void reload(optional boolean hardReload = false);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void stop();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest download(DOMString url,
                       optional BrowserElementDownloadOptions options);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest purgeHistory();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest getScreenshot([EnforceRange] unsigned long width,
                            [EnforceRange] unsigned long height,
                            optional DOMString mimeType="");
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void zoom(float zoom);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest getCanGoBack();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest getCanGoForward();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest getContentDimensions();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest setInputMethodActive(boolean isActive);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void setNFCFocus(boolean isFocus);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void findAll(DOMString searchString, BrowserFindCaseSensitivity caseSensitivity);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void findNext(BrowserFindDirection direction);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   void clearMatch();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest executeScript(DOMString script,
                            optional BrowserElementExecuteScriptOptions options);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
-   ChromeOnly]
+   Func="nsDocument::IsBrowserElementEnabled"]
   DOMRequest getWebManifest();
 
 };

--- a/dom/webidl/HTMLIFrameElement.webidl
+++ b/dom/webidl/HTMLIFrameElement.webidl
@@ -54,7 +54,7 @@ partial interface HTMLIFrameElement {
 
 partial interface HTMLIFrameElement {
   // nsIDOMMozBrowserFrame
-  [ChromeOnly,SetterThrows]
+  [Func="nsDocument::IsBrowserElementEnabled",SetterThrows]
            attribute boolean mozbrowser;
 };
 

--- a/positron/app/positron.js
+++ b/positron/app/positron.js
@@ -4,6 +4,7 @@
 
 pref("browser.dom.window.dump.enabled", true);
 pref("dom.mozBrowserFramesEnabled", true);
+pref("dom.mozBrowserFramesEnabledForContent", true);
 pref("dom.webcomponents.enabled", true);
 pref("javascript.options.showInConsole", true);
 pref("devtools.selfxss.count", 5);

--- a/positron/components/ModuleLoader.jsm
+++ b/positron/components/ModuleLoader.jsm
@@ -212,11 +212,10 @@ function ModuleLoader(processType, window) {
   //
   this.process = this.require({}, 'resource:///modules/gecko/process.js');
 
-  // In the browser process, assign global.process to this.process directly.
-  // In a renderer process, the WebIDL binding sets global.process.
-  if (processType === 'browser') {
-    this.global.process = this.process;
-  }
+  // Define 'process' in the sandbox so that modules loaded in the sandbox
+  // have access to it.  This doesn't enable a page in a renderer process
+  // to access the value.  For that, we still need to expose it via WebIDL.
+  sandbox.process = this.process;
 
   this.global.Buffer = this.require({}, 'resource:///modules/node/buffer.js').Buffer;
 

--- a/positron/components/ModuleLoader.jsm
+++ b/positron/components/ModuleLoader.jsm
@@ -213,7 +213,7 @@ function ModuleLoader(processType, window) {
   this.process = this.require({}, 'resource:///modules/gecko/process.js');
 
   // Define 'process' in the sandbox so that modules loaded in the sandbox
-  // have access to it.  This doesn't enable a page in a renderer process
+  // have direct access to it.  This doesn't enable a page in a renderer process
   // to access the value.  For that, we still need to expose it via WebIDL.
   sandbox.process = this.process;
 

--- a/positron/components/Process.js
+++ b/positron/components/Process.js
@@ -38,6 +38,19 @@ Process.prototype = {
    * for an explanation of the behavior of this method.
    */
   init: function(window) {
+    // This isn't quite right, since we actually want window.process to remain
+    // uninitialized if !window.processImpl, which indicates that the window
+    // doesn't have access to the window.process global.  I wish we could return
+    // the undefined value, but that triggers a "permission denied" error
+    // when the page tries to access the global property, which seems weirder
+    // than the behavior when the property is set to null.
+    //
+    // TODO: prevent initialization of window.process when !window.processImpl.
+    //
+    if (!window.processImpl) {
+      return null;
+    }
+
     this._contentWindow = window;
 
     // The WebIDL binding applies to the hidden window too, but we don't want

--- a/positron/components/Process.manifest
+++ b/positron/components/Process.manifest
@@ -1,3 +1,3 @@
 component {3c81d709-5fb4-4144-9612-9ecc1be4e7b1} Process.js
 contract @mozilla.org/positron/process;1 {3c81d709-5fb4-4144-9612-9ecc1be4e7b1}
-category JavaScript-global-privileged-property process @mozilla.org/positron/process;1
+category JavaScript-global-property process @mozilla.org/positron/process;1

--- a/positron/modules/atom_browser_window.js
+++ b/positron/modules/atom_browser_window.js
@@ -78,7 +78,7 @@ BrowserWindow.prototype = {
     ppmm.broadcastAsyncMessage('ipc-message', [channel].concat(args), { window: this._domWindow });
   },
 
-  _enableBrowserElement: function(url) {
+  _enableBrowserElementForURL: function(url) {
     let uri = Services.io.newURI(url, null, null);
     if (uri.scheme !== 'https' && uri.scheme !== 'file') {
       console.warn(`not enabling mozbrowser for ${url}`);
@@ -116,7 +116,7 @@ BrowserWindow.prototype = {
     };
     Services.obs.addObserver(observer, 'document-element-inserted', false);
 
-    this._enableBrowserElement(url);
+    this._enableBrowserElementForURL(url);
 
     this._domWindow.location = url;
   },

--- a/positron/modules/atom_browser_window.js
+++ b/positron/modules/atom_browser_window.js
@@ -78,6 +78,21 @@ BrowserWindow.prototype = {
     ppmm.broadcastAsyncMessage('ipc-message', [channel].concat(args), { window: this._domWindow });
   },
 
+  _enableBrowserElement: function(url) {
+    let uri = Services.io.newURI(url, null, null);
+    if (uri.scheme !== 'https' && uri.scheme !== 'file') {
+      console.warn(`not enabling mozbrowser for ${url}`);
+      return;
+    }
+
+    console.log(`enabling mozbrowser for ${url}`);
+    Services.perms.add(uri, "browser", Services.perms.ALLOW_ACTION);
+
+    // TODO: remove URL once BrowserWindow is closed?  Otherwise, if the app
+    // gets updated to a version that no longer opens a BrowserWindow
+    // to that URL, the permission will persist unnecessarily.
+  },
+
   _loadURL: function(url) {
     // Observe document-element-inserted and eagerly create the module loader,
     // so <webview> is available by the time the document loads.
@@ -100,6 +115,8 @@ BrowserWindow.prototype = {
       },
     };
     Services.obs.addObserver(observer, 'document-element-inserted', false);
+
+    this._enableBrowserElement(url);
 
     this._domWindow.location = url;
   },

--- a/positron/webidl/Process.webidl
+++ b/positron/webidl/Process.webidl
@@ -29,7 +29,7 @@ interface EventEmitter {
 
 // This currently specifies only a subset of the attributes and operations
 // of the process global as specified by Node.
-[ChromeOnly,
+[Func="nsDocument::IsBrowserElementEnabled",
  JSImplementation="@mozilla.org/positron/process;1"]
 interface processImpl : EventEmitter {
   [Cached, Pure] readonly attribute sequence<DOMString> argv;

--- a/positron/webidl/Process.webidl
+++ b/positron/webidl/Process.webidl
@@ -19,8 +19,7 @@ dictionary VersionDictionary {
 
 // EventEmitter isn't instantiated, its methods are just accessed
 // on processImpl.  So it doesn't need a real contract ID.
-[ChromeOnly,
- JSImplementation="dummy"]
+[JSImplementation="dummy"]
 interface EventEmitter {
   [Throws]
   EventEmitter once(DOMString name, Function listener);
@@ -29,6 +28,14 @@ interface EventEmitter {
 
 // This currently specifies only a subset of the attributes and operations
 // of the process global as specified by Node.
+//
+// Currently we reuse nsDocument::IsBrowserElementEnabled to determine
+// whether or not to enable this global, since the only consumer is Positron,
+// which always wants this global when it wants the mozbrowser API.
+// But ideally we'd give this global its own function, so Positron apps
+// can specify whether or not they want Node integration in BrowserWindows,
+// and we can disable it even when the mozbrowser API is enabled.
+//
 [Func="nsDocument::IsBrowserElementEnabled",
  JSImplementation="@mozilla.org/positron/process;1"]
 interface processImpl : EventEmitter {


### PR DESCRIPTION
@brendandahl This branch enables mozbrowser for specific origins instead of giving the system principal to all top-level docshell loads, per comments from @bz and @jryans in [bug 1290272](https://bugzilla.mozilla.org/show_bug.cgi?id=1290272).

In theory, it should enable us to expose mozbrowser to BrowserWindow instances without giving them the system principal. But in practice, some of the code we load in BrowserWindow instances needs that principal in order to access Components, so we'd need to disentangle that code from the code that doesn't. So this isn't ready to land yet.
