### PR TITLE
[WIP] Fix the libuv event loop for mac and linux.

### DIFF
--- a/positron/components/PositronAppRunner.jsm
+++ b/positron/components/PositronAppRunner.jsm
@@ -63,7 +63,7 @@ PositronAppRunner.prototype = {
     };
     let nodeLoader = Cc["@mozilla.org/positron/nodeloader;1"]
                      .getService(Ci.nsINodeLoader);
-    nodeLoader.init();
+    nodeLoader.init("browser");
   },
 
   _parsePackageJSON: function par_parsePackageJSON(aData) {

--- a/positron/webidl/LICENSE
+++ b/positron/webidl/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2014 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/positron/webidl/Makefile.in
+++ b/positron/webidl/Makefile.in
@@ -7,7 +7,6 @@ include $(topsrcdir)/config/config.mk
 # SpiderNode's ICU dependency uses typeid and dynamic_cast, so we need
 # to enable RTTI for it.  Erm, I guess this enables RTTI for the whole build,
 # but I'm unsure how to do so just for the submake of SpiderNode.
-CXXFLAGS += -frtti
 
 ifdef MOZ_DEBUG
 BUILDTYPE = Debug
@@ -41,7 +40,7 @@ SPIDERNODE_LIB_PATHS = $(foreach file,$(SPIDERNODE_LIBS),$(topsrcdir)/positron/s
 # 			(or configure positron to look for the libraries in the spidernode output directory)
 
 spidernode:
-	$(MAKE) -C $(topsrcdir)/positron/spidernode BUILDTYPE=$(BUILDTYPE)
+	$(MAKE) -C $(topsrcdir)/positron/spidernode/out BUILDTYPE=$(BUILDTYPE)
 
 $(SPIDERNODE_LIB_PATHS): spidernode
 

--- a/positron/webidl/NodeBindings.cpp
+++ b/positron/webidl/NodeBindings.cpp
@@ -1,0 +1,282 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "NodeBindings.h"
+
+#include <string>
+#include <vector>
+
+#include "mozilla/dom/ScriptSettings.h" // for AutoJSAPI
+#include "base/message_loop.h"
+#include "nsIFile.h"
+#include "nsDirectoryService.h"
+#include "nsDirectoryServiceDefs.h"
+#include "env-inl.h"
+#include "jsapi.h"
+#include "nsString.h"
+#include "nsAppRunner.h"
+
+namespace mozilla {
+
+NodeBindings::NodeBindings(bool is_browser)
+    : is_browser_(is_browser),
+      message_loop_(nullptr),
+      uv_loop_(uv_default_loop()),
+      embed_closed_(false),
+      uv_env_(nullptr) {
+}
+
+NodeBindings::~NodeBindings() {
+  // Quit the embed thread.
+  embed_closed_ = true;
+  uv_sem_post(&embed_sem_);
+  WakeupEmbedThread();
+
+  // Wait for everything to be done.
+  uv_thread_join(&embed_thread_);
+
+  // Clear uv.
+  uv_sem_destroy(&embed_sem_);
+}
+
+void NodeBindings::Initialize(JSContext* aContext) {
+  v8::V8::Initialize();
+  uv_async_init(uv_default_loop(), &call_next_tick_async_, OnCallNextTick);
+  call_next_tick_async_.data = this;
+
+  v8::Isolate* isolate = v8::Isolate::New(aContext);
+  // v8::Isolate::Scope isolate_scope(isolate);
+  // TODO: FIX THIS LEAK
+  v8::Isolate::Scope* isolate_scope = new v8::Isolate::Scope(isolate);
+  v8::HandleScope handle_scope(isolate);
+
+  v8::Local<v8::Context> context = v8::Context::New(isolate);
+  // v8::Context::Scope context_scope(context);
+  // TODO: FIX THIS LEAK
+  v8::Context::Scope* context_scope = new v8::Context::Scope(context);
+
+  node::Environment* env = CreateEnvironment(context);
+  set_uv_env(env);
+  uv_loop_ = uv_default_loop();
+  PreMainMessageLoopRun();
+  LoadEnvironment(env);
+}
+
+// In electron, this function is in atom bindings.
+static void ActivateUVLoopCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Local<v8::External> this_value = v8::Local<v8::External>::Cast(info.Data());
+  NodeBindings* nodeBindings = static_cast<NodeBindings*>(this_value->Value());
+  nodeBindings->ActivateUVLoop(v8::Isolate::GetCurrent());
+}
+
+node::Environment* NodeBindings::CreateEnvironment(
+    v8::Handle<v8::Context> context) {
+  // Build the path to the init script.
+  nsCOMPtr<nsIFile> greDir;
+  nsDirectoryService::gService->Get(NS_GRE_DIR,
+                                    NS_GET_IID(nsIFile),
+                                    getter_AddRefs(greDir));
+  MOZ_ASSERT(greDir);
+  greDir->AppendNative(NS_LITERAL_CSTRING("modules"));
+  greDir->AppendNative(is_browser_ ? NS_LITERAL_CSTRING("browser") :
+                                     NS_LITERAL_CSTRING("renderer"));
+  greDir->AppendNative(NS_LITERAL_CSTRING("init.js"));
+  nsAutoString initalScript;
+  greDir->GetPath(initalScript);
+
+  int exec_argc;
+  const char** exec_argv;
+  int argc = 2;
+  char **argv = new char *[argc + 1];
+  argv[0] = gArgv[0];
+  argv[1] = ToNewCString(NS_LossyConvertUTF16toASCII(initalScript));
+  node::Init(&argc, const_cast<const char**>(argv),  &exec_argc, &exec_argv);
+
+  // Convert the app path to an absolute app path.
+  nsCOMPtr<nsIFile> cwdDir;
+  nsDirectoryService::gService->Get(NS_OS_CURRENT_WORKING_DIR,
+                                    NS_GET_IID(nsIFile),
+                                    getter_AddRefs(cwdDir));
+  MOZ_ASSERT(cwdDir);
+
+  char* absoluteAppPath = nullptr;
+  nsDependentCString appPath(gArgv[1]);
+  // Try the path as a relative path to the current working directory.
+  nsresult rv = cwdDir->AppendRelativeNativePath(appPath);
+  if (NS_SUCCEEDED(rv)) {
+    nsString absoluteAppPathString;
+    rv = cwdDir->GetPath(absoluteAppPathString);
+    if (NS_FAILED(rv)) {
+      MOZ_CRASH("Unable to build absolute app path.");
+    }
+    absoluteAppPath = ToNewCString(NS_LossyConvertUTF16toASCII(absoluteAppPathString));
+  } else { // It's hopefully an absolute path.
+    absoluteAppPath = gArgv[1];
+  }
+
+  v8::Isolate* isolate = context->GetIsolate();
+  node::IsolateData* isolateData = node::CreateIsolateData(isolate, uv_default_loop());
+  node::Environment* env = node::CreateEnvironment(
+    isolateData,
+    context,
+    argc, argv, 0, nullptr);
+
+  env->process_object()->Set(v8::String::NewFromUtf8(isolate, "resourcesPath"),
+                             v8::String::NewFromUtf8(isolate, absoluteAppPath));
+  env->process_object()->Set(v8::String::NewFromUtf8(isolate, "type"),
+                             v8::String::NewFromUtf8(isolate, is_browser_ ? "browser" : "renderer"));
+
+  v8::Local<v8::Value> this_value = v8::External::New(isolate, this);
+  v8::Local<v8::FunctionTemplate> acc = v8::FunctionTemplate::New(isolate, ActivateUVLoopCallback, this_value);
+  env->process_object()->Set(context, v8::String::NewFromUtf8(isolate,
+                             "activateUvLoop"),
+                             acc->GetFunction(context).ToLocalChecked());
+
+  return env;
+}
+
+void NodeBindings::PreMainMessageLoopRun() {
+  // Run user's main script before most things get initialized, so we can have
+  // a chance to setup everything.
+  PrepareMessageLoop();
+  RunMessageLoop();
+}
+
+// In electron, this function is in atom bindings.
+void NodeBindings::ActivateUVLoop(v8::Isolate* isolate) {
+  node::Environment* env = node::Environment::GetCurrent(isolate);
+  if (std::find(pending_next_ticks_.begin(), pending_next_ticks_.end(), env) !=
+      pending_next_ticks_.end())
+    return;
+
+  pending_next_ticks_.push_back(env);
+  uv_async_send(&call_next_tick_async_);
+}
+
+// In electron, this function is in atom bindings.
+// static
+void NodeBindings::OnCallNextTick(uv_async_t* handle) {
+  NodeBindings* self = static_cast<NodeBindings*>(handle->data);
+  for (std::list<node::Environment*>::const_iterator it =
+           self->pending_next_ticks_.begin();
+       it != self->pending_next_ticks_.end(); ++it) {
+    node::Environment* env = *it;
+    // KickNextTick, copied from node.cc:
+    node::Environment::AsyncCallbackScope callback_scope(env);
+    if (callback_scope.in_makecallback())
+      continue;
+    node::Environment::TickInfo* tick_info = env->tick_info();
+    if (tick_info->length() == 0)
+      env->isolate()->RunMicrotasks();
+    v8::Local<v8::Object> process = env->process_object();
+    if (tick_info->length() == 0)
+      tick_info->set_index(0);
+    env->tick_callback_function()->Call(process, 0, nullptr).IsEmpty();
+  }
+
+  self->pending_next_ticks_.clear();
+}
+
+void NodeBindings::LoadEnvironment(node::Environment* env) {
+  node::LoadEnvironment(env);
+  // TODO
+  // mate::EmitEvent(env->isolate(), env->process_object(), "loaded");
+}
+
+void NodeBindings::PrepareMessageLoop() {
+  MOZ_ASSERT(!is_browser_ || NS_IsMainThread());
+  // Add dummy handle for libuv, otherwise libuv would quit when there is
+  // nothing to do.
+  uv_async_init(uv_loop_, &dummy_uv_handle_, nullptr);
+
+  // Start worker that will interrupt main loop when having uv events.
+  uv_sem_init(&embed_sem_, 0);
+  uv_thread_create(&embed_thread_, EmbedThreadRunner, this);
+}
+
+void NodeBindings::RunMessageLoop() {
+  MOZ_ASSERT(!is_browser_ || NS_IsMainThread());
+
+  // The MessageLoop should have been created, remember the one in main thread.
+  message_loop_ = MessageLoop::current();
+
+  // Run uv loop for once to give the uv__io_poll a chance to add all events.
+  UvRunOnce();
+}
+
+void NodeBindings::UvRunOnce() {
+  MOZ_ASSERT(!is_browser_ || NS_IsMainThread());
+  node::Environment* env = uv_env();
+
+  v8::Isolate::Scope isolate_scope(env->isolate());
+
+  // TODO
+  // Use Locker in browser process.
+  // mate::Locker locker(env->isolate());
+  v8::HandleScope handle_scope(env->isolate());
+
+  // Enter node context while dealing with uv events.
+  v8::Context::Scope context_scope(env->context());
+
+  // Perform microtask checkpoint after running JavaScript.
+  v8::MicrotasksScope script_scope(env->isolate(),
+                                   v8::MicrotasksScope::kRunMicrotasks);
+
+  JSContext* cx = JSContextFromIsolate(env->isolate());
+  MOZ_ASSERT(cx);
+  JSObject* globalObject = JS::CurrentGlobalOrNull(cx);
+  MOZ_ASSERT(globalObject);
+  dom::AutoEntryScript aes(globalObject, "NodeBindings UvRunOnce");
+
+  // Deal with uv events.
+  int r = uv_run(uv_loop_, UV_RUN_NOWAIT);
+  if (r == 0) {
+    // Quit from uv.
+    // XXX: This hasn't been verified as the correct thing to do, but electron's
+    // oringal code was message_loop_->QuitWhenIdle(), and this appears to be
+    // the gecko equivalent.
+    RefPtr<Runnable> task = new MessageLoop::QuitTask();
+    message_loop_->PostIdleTask(task.forget());
+  }
+
+  // Tell the worker thread to continue polling.
+  uv_sem_post(&embed_sem_);
+}
+
+
+void NodeBindings::WakeupMainThread() {
+  MOZ_ASSERT(message_loop_);
+
+  message_loop_->PostTask(NewRunnableMethod(this, &NodeBindings::UvRunOnce));
+}
+
+void NodeBindings::WakeupEmbedThread() {
+  uv_async_send(&dummy_uv_handle_);
+}
+
+// static
+void NodeBindings::EmbedThreadRunner(void *arg) {
+  NodeBindings* self = static_cast<NodeBindings*>(arg);
+
+  while (true) {
+    // Wait for the main loop to deal with events.
+    uv_sem_wait(&self->embed_sem_);
+    if (self->embed_closed_)
+      break;
+
+    // Wait for something to happen in uv loop.
+    // Note that the PollEvents() is implemented by derived classes, so when
+    // this class is being destructed the PollEvents() would not be available
+    // anymore. Because of it we must make sure we only invoke PollEvents()
+    // when this class is alive.
+    self->PollEvents();
+    if (self->embed_closed_)
+      break;
+
+    // Deal with event in main thread.
+    self->WakeupMainThread();
+  }
+}
+
+}  // namespace atom

--- a/positron/webidl/NodeBindings.h
+++ b/positron/webidl/NodeBindings.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef MOZILLA_COMMON_NODE_BINDINGS_H_
+#define MOZILLA_COMMON_NODE_BINDINGS_H_
+
+#include <list>
+#include "node.h"
+#include "uv.h"
+#include "nsISupportsImpl.h"
+
+class MessageLoop;
+
+namespace node {
+class Environment;
+}
+
+namespace mozilla {
+
+class NodeBindings {
+ public:
+  // Needed to use message loop's PostTask
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(mozilla::NodeBindings);
+
+  static NodeBindings* Create(bool is_browser);
+
+  // Setup V8, libuv.
+  void Initialize(JSContext* aContext);
+
+  // Create the environment and load node.js.
+  node::Environment* CreateEnvironment(v8::Handle<v8::Context> context);
+
+  // Load node.js in the environment.
+  void LoadEnvironment(node::Environment* env);
+
+  // Prepare for message loop integration.
+  void PrepareMessageLoop();
+
+  // Do message loop integration.
+  virtual void RunMessageLoop();
+
+  // Gets/sets the environment to wrap uv loop.
+  void set_uv_env(node::Environment* env) { uv_env_ = env; }
+  node::Environment* uv_env() const { return uv_env_; }
+
+  void ActivateUVLoop(v8::Isolate* isolate);
+
+ protected:
+  explicit NodeBindings(bool is_browser);
+  // Made protected for ref counting.
+  virtual ~NodeBindings();
+
+  // Called to poll events in new thread.
+  virtual void PollEvents() = 0;
+
+  // Run the libuv loop for once.
+  void UvRunOnce();
+
+  // Make the main thread run libuv loop.
+  void WakeupMainThread();
+
+  // Interrupt the PollEvents.
+  void WakeupEmbedThread();
+
+  // Are we running in browser.
+  bool is_browser_;
+
+  // Main thread's MessageLoop.
+  MessageLoop* message_loop_;
+
+  // Main thread's libuv loop.
+  uv_loop_t* uv_loop_;
+
+ private:
+  // Thread to poll uv events.
+  static void EmbedThreadRunner(void *arg);
+
+  // Whether the libuv loop has ended.
+  bool embed_closed_;
+
+  // Dummy handle to make uv's loop not quit.
+  uv_async_t dummy_uv_handle_;
+
+  // Thread for polling events.
+  uv_thread_t embed_thread_;
+
+  // Semaphore to wait for main loop in the embed thread.
+  uv_sem_t embed_sem_;
+
+  // Environment that to wrap the uv loop.
+  node::Environment* uv_env_;
+
+  static void OnCallNextTick(uv_async_t* handle);
+  uv_async_t call_next_tick_async_;
+  std::list<node::Environment*> pending_next_ticks_;
+  void PreMainMessageLoopRun();
+};
+
+}  // namespace mozilla
+
+#endif  // MOZILLA_COMMON_NODE_BINDINGS_H_

--- a/positron/webidl/NodeBindingsLinux.cpp
+++ b/positron/webidl/NodeBindingsLinux.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2014 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "NodeBindingsLinux.h"
+
+#include <sys/epoll.h>
+
+namespace mozilla {
+
+NodeBindingsLinux::NodeBindingsLinux(bool is_browser)
+    : NodeBindings(is_browser),
+      epoll_(epoll_create(1)) {
+  int backend_fd = uv_backend_fd(uv_loop_);
+  struct epoll_event ev = { 0 };
+  ev.events = EPOLLIN;
+  ev.data.fd = backend_fd;
+  epoll_ctl(epoll_, EPOLL_CTL_ADD, backend_fd, &ev);
+}
+
+NodeBindingsLinux::~NodeBindingsLinux() {
+}
+
+void NodeBindingsLinux::RunMessageLoop() {
+  // Get notified when libuv's watcher queue changes.
+  uv_loop_->data = this;
+  uv_loop_->on_watcher_queue_updated = OnWatcherQueueChanged;
+
+  NodeBindings::RunMessageLoop();
+}
+
+// static
+void NodeBindingsLinux::OnWatcherQueueChanged(uv_loop_t* loop) {
+  NodeBindingsLinux* self = static_cast<NodeBindingsLinux*>(loop->data);
+
+  // We need to break the io polling in the epoll thread when loop's watcher
+  // queue changes, otherwise new events cannot be notified.
+  self->WakeupEmbedThread();
+}
+
+void NodeBindingsLinux::PollEvents() {
+  int timeout = uv_backend_timeout(uv_loop_);
+
+  // Wait for new libuv events.
+  int r;
+  do {
+    struct epoll_event ev;
+    r = epoll_wait(epoll_, &ev, 1, timeout);
+  } while (r == -1 && errno == EINTR);
+}
+
+// static
+NodeBindings* NodeBindings::Create(bool is_browser) {
+  return new NodeBindingsLinux(is_browser);
+}
+
+}  // namespace mozilla

--- a/positron/webidl/NodeBindingsLinux.h
+++ b/positron/webidl/NodeBindingsLinux.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2014 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef MOZILLA_COMMON_NODE_BINDINGS_LINUX_H_
+#define MOZILLA_COMMON_NODE_BINDINGS_LINUX_H_
+
+#include "NodeBindings.h"
+
+namespace mozilla {
+
+class NodeBindingsLinux : public NodeBindings {
+ public:
+  explicit NodeBindingsLinux(bool is_browser);
+  virtual ~NodeBindingsLinux();
+
+  void RunMessageLoop() override;
+
+ private:
+  // Called when uv's watcher queue changes.
+  static void OnWatcherQueueChanged(uv_loop_t* loop);
+
+  void PollEvents() override;
+
+  // Epoll to poll for uv's backend fd.
+  int epoll_;
+
+  DISALLOW_COPY_AND_ASSIGN(NodeBindingsLinux);
+};
+
+}  // namespace atom
+
+#endif  // MOZILLA_COMMON_NODE_BINDINGS_LINUX_H_

--- a/positron/webidl/NodeBindingsMac.cpp
+++ b/positron/webidl/NodeBindingsMac.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "NodeBindingsMac.h"
+
+#include <errno.h>
+#include <sys/select.h>
+#include <sys/sysctl.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+#include "uv.h"
+
+namespace mozilla {
+
+NodeBindingsMac::NodeBindingsMac(bool is_browser)
+    : NodeBindings(is_browser) {
+}
+
+NodeBindingsMac::~NodeBindingsMac() {
+}
+
+void NodeBindingsMac::RunMessageLoop() {
+  // Get notified when libuv's watcher queue changes.
+  uv_loop_->data = this;
+  uv_loop_->on_watcher_queue_updated = OnWatcherQueueChanged;
+
+  NodeBindings::RunMessageLoop();
+}
+
+// static
+void NodeBindingsMac::OnWatcherQueueChanged(uv_loop_t* loop) {
+  NodeBindingsMac* self = static_cast<NodeBindingsMac*>(loop->data);
+
+  // We need to break the io polling in the kqueue thread when loop's watcher
+  // queue changes, otherwise new events cannot be notified.
+  self->WakeupEmbedThread();
+}
+
+void NodeBindingsMac::PollEvents() {
+  struct timeval tv;
+  int timeout = uv_backend_timeout(uv_loop_);
+  if (timeout != -1) {
+    tv.tv_sec = timeout / 1000;
+    tv.tv_usec = (timeout % 1000) * 1000;
+  }
+
+  fd_set readset;
+  int fd = uv_backend_fd(uv_loop_);
+  FD_ZERO(&readset);
+  FD_SET(fd, &readset);
+
+  // Wait for new libuv events.
+  int r;
+  do {
+    r = select(fd + 1, &readset, NULL, NULL, timeout == -1 ? NULL : &tv);
+  } while (r == -1 && errno == EINTR);
+}
+
+// static
+NodeBindings* NodeBindings::Create(bool is_browser) {
+  return new NodeBindingsMac(is_browser);
+}
+
+}  // namespace mozilla

--- a/positron/webidl/NodeBindingsMac.h
+++ b/positron/webidl/NodeBindingsMac.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef MOZILLA_COMMON_NODE_BINDINGS_MAC_H_
+#define MOZILLA_COMMON_NODE_BINDINGS_MAC_H_
+
+#include "NodeBindings.h"
+
+namespace mozilla {
+
+class NodeBindingsMac : public NodeBindings {
+ public:
+  explicit NodeBindingsMac(bool is_browser);
+
+  void RunMessageLoop() override;
+
+ private:
+  virtual ~NodeBindingsMac();
+  // Called when uv's watcher queue changes.
+  static void OnWatcherQueueChanged(uv_loop_t* loop);
+
+  void PollEvents() override;
+};
+
+}  // namespace mozilla
+
+#endif  // MOZILLA_COMMON_NODE_BINDINGS_MAC_H_

--- a/positron/webidl/NodeLoader.h
+++ b/positron/webidl/NodeLoader.h
@@ -9,17 +9,19 @@
 
 #include "nsINodeLoader.h"
 #include "nsISupports.h"
+#include "NodeBindings.h"
 
 class NodeLoader final : public nsINodeLoader
 {
 public:
-  NS_DECL_ISUPPORTS
+  NS_DECL_THREADSAFE_ISUPPORTS
   NS_DECL_NSINODELOADER
 
   NodeLoader();
 
 private:
   ~NodeLoader();
+  RefPtr<mozilla::NodeBindings> nodeBindings;
 
 protected:
   /* additional members */

--- a/positron/webidl/moz.build
+++ b/positron/webidl/moz.build
@@ -47,9 +47,22 @@ EXPORTS += [
 ]
 
 SOURCES += [
+    'NodeBindings.cpp',
     'NodeLoader.cpp',
 ]
+
+if CONFIG['OS_ARCH'] == 'Darwin':
+    SOURCES += [
+        'NodeBindingsMac.cpp',
+    ]
+
+if CONFIG['OS_ARCH'] == 'Linux':
+    SOURCES += [
+        'NodeBindingsLinux.cpp',
+    ]
 
 XPIDL_MODULE = 'positron'
 
 FINAL_LIBRARY = 'xul'
+
+include('/ipc/chromium/chromium-config.mozbuild')

--- a/positron/webidl/nsINodeLoader.idl
+++ b/positron/webidl/nsINodeLoader.idl
@@ -7,5 +7,5 @@
 
 [scriptable, uuid(93251ddf-5e85-4172-ac2a-31780562974a)]
 interface nsINodeLoader : nsISupports {
-  [implicit_jscontext] void init();
+  [implicit_jscontext] void init(in ACString type);
 };


### PR DESCRIPTION
Event loop now runs and it's possible to do a hello world example with a server, but I'm currently getting a compartment mismatch crash on shutdown. I also have a have few TODO's in there that I'm still looking at to see if I need to address them.

example changes to hello world

```(diff)
+++ b/positron/test/hello-world/main.js
@@ -24,7 +24,7 @@ app.on('ready', function() {
     mainWindow = new BrowserWindow({width: 800, height: 600});
 
     // and load the index.html of the app.
-    mainWindow.loadURL('file://' + __dirname + '/index.html');
+    mainWindow.loadURL('http://localhost:8000');
 
     // Open the DevTools.
     mainWindow.webContents.openDevTools();
@@ -37,3 +37,15 @@ app.on('ready', function() {
        mainWindow = null;
     });
 });
+
+// Load the http module to create an http server.
+var http = require('http');
+
+// Configure our HTTP server to respond with Hello World to all requests.
+var server = http.createServer(function (request, response) {
+  response.writeHead(200, {"Content-Type": "text/plain"});
+  response.end("Hello World from node " + process.versions.node + "\n");
+});
+
+// Listen on port 8000, IP defaults to 127.0.0.1
+server.listen(8000);
```