### PR TITLE
build specific type (reverts Windows fix)

### DIFF
--- a/positron/webidl/Makefile.in
+++ b/positron/webidl/Makefile.in
@@ -41,7 +41,7 @@ SPIDERNODE_LIB_PATHS = $(foreach file,$(SPIDERNODE_LIBS),$(topsrcdir)/positron/s
 # 			(or configure positron to look for the libraries in the spidernode output directory)
 
 spidernode:
-	$(MAKE) -C $(topsrcdir)/positron/spidernode BUILDTYPE=$(BUILDTYPE)
+	$(MAKE) -C $(topsrcdir)/positron/spidernode/out BUILDTYPE=$(BUILDTYPE)
 
 $(SPIDERNODE_LIB_PATHS): spidernode
 


### PR DESCRIPTION
@brendandahl I know you reverted this on #113, but it's worth landing early, while that branch is still a WIP.

The change reverts a fix I landed earlier for Windows, but Windows has bigger problems, and it isn't clear that the earlier fix will still be needed once those problems are resolved. So we might as well make life easier on Mac/Linux in the meantime.
