### PR TITLE
finish cherry-picking taskcluster improvements by adding mozconfig files

### DIFF
--- a/positron/config/mozconfig
+++ b/positron/config/mozconfig
@@ -1,0 +1,4 @@
+ac_add_options --disable-export-js
+ac_add_options --disable-shared-js
+ac_add_options --disable-js-shell
+ac_add_options --enable-sm-promise

--- a/positron/config/mozconfig-debug
+++ b/positron/config/mozconfig-debug
@@ -1,0 +1,5 @@
+. $topsrcdir/positron/config/mozconfig
+
+# Build debug.
+ac_add_options --disable-optimize
+ac_add_options --enable-debug


### PR DESCRIPTION
#122 was an incomplete cherry-pick that broke TaskCluster runs. This PR adds the two missing mozconfig files.
