### PR TITLE
update positron/electron submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "positron/electron"]
 	path = positron/electron
 	url = https://github.com/mozilla/positron-electron.git
+	branch = master
 [submodule "positron/spidernode"]
 	path = positron/spidernode
 	url = https://github.com/mozilla/positron-spidernode.git


### PR DESCRIPTION
This updates the positron/electron submodule to the latest tip of the submodule repository (now that I've merged https://github.com/mozilla/positron-electron/pull/1), which undoes a couple of workarounds that are no longer needed now that upstream Gecko implements `for (let … of …)` correctly.

It also sets the "branch" of the submodule to master, which seems like the right thing to do, even though it isn't clear what the submodule's "branch" setting does.
