### PR TITLE
merge upstream Gecko again

### DIFF
--- a/positron/config/mozconfig
+++ b/positron/config/mozconfig
@@ -1,4 +1,3 @@
 ac_add_options --disable-export-js
 ac_add_options --disable-shared-js
 ac_add_options --disable-js-shell
-ac_add_options --enable-sm-promise


### PR DESCRIPTION
I didn't notice this when I merged #152, but for some reason the Gecko merge produced a non-merge commit containing the diff between the two branches instead of a merge commit that add the upstream commits as a branch.

I have no idea why, since I didn't do anything unusual, just `git merge gecko-dev/master` (where "gecko-dev" is the name of the remote for https://github.com/mozilla/gecko-dev).

In any case, here's a merge commit that actually merges the branches. The command I invoked is the same, `git merge gecko-dev/master`, but the output is what I expected the first time around (and should have confirmed before merging the pull request).

On this branch, when I `git merge gecko-dev/master`, then Git says the branch is "Already up-to-date." So merging this branch should get things into a good state.
